### PR TITLE
#9 Fix Autocomplete error message displaying above tags

### DIFF
--- a/libs/form-elements/src/Field.tsx
+++ b/libs/form-elements/src/Field.tsx
@@ -44,7 +44,7 @@ export type FieldProps = {
   fieldClassName?: string;
 
   /**
-   * The help text displayed below the field and content defined with placeBelow prop (not exclusively text).
+   * The help text displayed below the field and content defined with addonBelow prop (not exclusively text).
    */
   help?: React.ReactNode;
 
@@ -67,7 +67,7 @@ export type FieldProps = {
    * Optional component displayed under the field component and above the help and error.
    * Useful for rendering arbitrary items under the field component.
    */
-  placeBelow?: React.ReactNode;
+  addonBelow?: React.ReactNode;
 
   /**
    * Turns this field into a required field in the form. Only applies visual representation (* next to label),
@@ -118,7 +118,7 @@ export default function Field({
   containerClassName,
   fieldClassName,
   children,
-  placeBelow,
+  addonBelow,
   ...props
 }: FieldProps) {
   const tokens = useTokens("Input", props.tokens);
@@ -132,7 +132,7 @@ export default function Field({
     <div className={containerClassName}>
       <FieldLabel id={id} label={label} required={required} tooltip={tooltip} {...props} />
       <div className={fieldClassName}>{children}</div>
-      {placeBelow && placeBelow}
+      {addonBelow && addonBelow}
       {error
         ? errorMessage && <p className={tokens.ErrorText.base}>{errorMessage}</p>
         : help && <p className={tokens.Help.base}>{help}</p>}

--- a/libs/form-elements/src/Field.tsx
+++ b/libs/form-elements/src/Field.tsx
@@ -23,27 +23,68 @@ import { ComponentTokens, useTokens } from "@tiller-ds/theme";
 import Label from "./Label";
 
 export type FieldProps = {
-  id?: string;
+  /**
+   * Field content (not exclusively text).
+   */
+  children: React.ReactNode;
 
-  name?: string;
-
-  label?: React.ReactNode;
-
-  tooltip?: React.ReactNode;
-
-  required?: boolean;
-
-  requiredLabel?: string;
-
-  help?: React.ReactNode;
-
-  error?: React.ReactNode;
-
+  /**
+   * Optional styling for the field container.
+   */
   containerClassName?: string;
 
+  /**
+   * Value passed through from validation indicating to display the error on the component.
+   */
+  error?: React.ReactNode;
+
+  /**
+   * Optional styling for the field component.
+   */
   fieldClassName?: string;
 
-  children: React.ReactNode;
+  /**
+   * The help text displayed below the field and content defined with placeBelow prop (not exclusively text).
+   */
+  help?: React.ReactNode;
+
+  /**
+   * Unique identifier passed onto the component.
+   */
+  id?: string;
+
+  /**
+   * Represents the label above the field.
+   */
+  label?: React.ReactNode;
+
+  /**
+   * The accessor value for the field component (for validation, fetching, etc.).
+   */
+  name?: string;
+
+  /**
+   * Optional component displayed under the field component and above the help and error.
+   * Useful for rendering arbitrary items under the field component.
+   */
+  placeBelow?: React.ReactNode;
+
+  /**
+   * Turns this field into a required field in the form. Only applies visual representation (* next to label),
+   * still requires validation on frontend or backend to accompany this value if set to true.
+   */
+  required?: boolean;
+
+  /**
+   * Text to display when hovering over a required symbol (*).
+   * Useful for bilingual purposes.
+   */
+  requiredLabel?: string;
+
+  /**
+   * Tooltip icon and text (on icon hover) displayed on the right of the label.
+   */
+  tooltip?: React.ReactNode;
 } & InputTokensProps;
 
 type InputTokensProps = {
@@ -77,6 +118,7 @@ export default function Field({
   containerClassName,
   fieldClassName,
   children,
+  placeBelow,
   ...props
 }: FieldProps) {
   const tokens = useTokens("Input", props.tokens);
@@ -90,6 +132,7 @@ export default function Field({
     <div className={containerClassName}>
       <FieldLabel id={id} label={label} required={required} tooltip={tooltip} {...props} />
       <div className={fieldClassName}>{children}</div>
+      {placeBelow && placeBelow}
       {error
         ? errorMessage && <p className={tokens.ErrorText.base}>{errorMessage}</p>
         : help && <p className={tokens.Help.base}>{help}</p>}

--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -225,7 +225,7 @@ export default function Input({
   });
 
   const extendClassName = cx({
-    "bg-white rounded-md": true,
+    "bg-white focus:outline-none rounded-md": true,
     "opacity-50": disabled,
   });
 

--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -104,7 +104,7 @@ export type InputProps = {
    * Optional component displayed under the field component and above the help and error.
    * Useful for rendering arbitrary items under the component.
    */
-  placeBelow?: React.ReactNode;
+  addonBelow?: React.ReactNode;
 
   /**
    * The placeholder displayed inside the input field.
@@ -180,7 +180,7 @@ export default function Input({
   allowClear = false,
   clearIcon,
   warningIcon,
-  placeBelow,
+  addonBelow,
   ...props
 }: InputProps) {
   const tokens = useTokens("Input", props.inputTokens);
@@ -249,7 +249,7 @@ export default function Input({
       error={error}
       containerClassName={className}
       fieldClassName={inputContainerClassName}
-      placeBelow={placeBelow}
+      addonBelow={addonBelow}
       {...props}
     >
       {addOn && <InputAddOn addOn={addOn} />}

--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -101,6 +101,12 @@ export type InputProps = {
   onReset?: () => void;
 
   /**
+   * Optional component displayed under the field component and above the help and error.
+   * Useful for rendering arbitrary items under the component.
+   */
+  placeBelow?: React.ReactNode;
+
+  /**
    * The placeholder displayed inside the input field.
    */
   placeholder?: string;
@@ -174,6 +180,7 @@ export default function Input({
   allowClear = false,
   clearIcon,
   warningIcon,
+  placeBelow,
   ...props
 }: InputProps) {
   const tokens = useTokens("Input", props.inputTokens);
@@ -242,6 +249,7 @@ export default function Input({
       error={error}
       containerClassName={className}
       fieldClassName={inputContainerClassName}
+      placeBelow={placeBelow}
       {...props}
     >
       {addOn && <InputAddOn addOn={addOn} />}

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -872,6 +872,7 @@ function Autocomplete<T extends {}>({
           </div>
         }
         extend={tags && tagsContained && tagsDisplay}
+        placeBelow={tags && !tagsContained && tagsDisplay}
         {...getInputProps({
           ref: !tagsContained ? toggleRef : inputRef,
           refKey: "inputRef",
@@ -882,7 +883,6 @@ function Autocomplete<T extends {}>({
         })}
         {...getComboboxProps({}, { suppressRefError: true })}
       />
-      {tags && !tagsContained && tagsDisplay}
       {allowMultiple && <input type="hidden" name={name} />}
       <Popover
         className="z-50"

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -872,7 +872,7 @@ function Autocomplete<T extends {}>({
           </div>
         }
         extend={tags && tagsContained && tagsDisplay}
-        placeBelow={tags && !tagsContained && tagsDisplay}
+        addonBelow={tags && !tagsContained && tagsDisplay}
         {...getInputProps({
           ref: !tagsContained ? toggleRef : inputRef,
           refKey: "inputRef",

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -698,7 +698,7 @@ function Autocomplete<T extends {}>({
                 <SelectItem key={index} index={index} option={option} />
               ) : (
                 inputValue &&
-                !tagExists() && <SelectItem tag={true} option={onAddCustomTag(inputValue)} index={index} />
+                !tagExists() && <SelectItem key={index} tag={true} option={onAddCustomTag(inputValue)} index={index} />
               )
             )}
         </>
@@ -768,7 +768,7 @@ function Autocomplete<T extends {}>({
               contentWrapper(
                 <>
                   <Intl name="autocomplete.addTag" /> {""}
-                  <Badge color="secondary" small={true}>
+                  <Badge color="secondary" dot={true} small={true}>
                     {safeItemToString(onAddCustomTag(inputValue))}
                   </Badge>
                 </>,

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -787,7 +787,7 @@ function Autocomplete<T extends {}>({
   };
 
   const content =
-    !tags && filteredOptions.length === 0 && !loading ? (
+    filteredOptions.length === 0 && !loading ? (
       <div className={selectItemClassName}>{noResultsPlaceholderContent}</div>
     ) : (
       <>
@@ -808,6 +808,7 @@ function Autocomplete<T extends {}>({
         ? (sort && !isOpen ? sort(selectedOptions) : selectedOptions).map((v, key) => (
             <Badge
               key={key}
+              dot={true}
               color={!arrayIncludes(customTags, v) ? "primary" : "secondary"}
               onRemoveButtonClick={() => {
                 const filtered = selectedOptions.filter((toFilter) => {

--- a/storybook/src/base-documentation/Introduction.stories.mdx
+++ b/storybook/src/base-documentation/Introduction.stories.mdx
@@ -30,7 +30,7 @@ For all questions and doubts, do not hesitate to email **tiller@croz.net**.
 
 Component Library is divided into `modules`. Each folder represents one module.
 
-To import a component, the corresponding module needs to be installed first. One way to install the module is to enter the name of the module in the `package.json` file in format `"@tiller-ds/core": "0.0.0-dev"` and run `yarn install`.
+To import a component, the corresponding module needs to be installed first. One way to install the module is to enter the name of the module in the `package.json` file in format `"@tiller-ds/core": "1.0.1"` and run `yarn install`.
 
 In case you are using `tiller-starter template`, `@tiller-ds/core` module will be installed by default.
 
@@ -52,5 +52,5 @@ If you are using the most recent version of Chrome and can’t access WebGL cont
 2. Use the search bar to locate the hardware acceleration setting, or scroll to the bottom of the Settings page, click **Advanced** and look in the **System** section.
 3. Toggle **Use hardware acceleration when available** to **on** (the toggle is blue when hardware acceleration is on, and white when hardware acceleration is off).
 
-In case option iz already set to **on**, **reset** it, and relaunch Chrome.
+In case option is already set to **on**, **reset** it, and relaunch Chrome.
 


### PR DESCRIPTION
## Basic information

* Tiller version: 1.0.1
* Module: form-elements

## Bug description

When using Autocomplete component with tags error message appears above the tags.

### Related issue

Closes #9

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
