### PR TITLE
#11 Fix always autofocus on Tabs

### DIFF
--- a/libs/core/src/Tabs.tsx
+++ b/libs/core/src/Tabs.tsx
@@ -122,7 +122,7 @@ export type CustomTabProps = {
   onClick?: (selectedIndex: number) => void;
 
   /**
-   * Make text unwrappable
+   * Make text unwrappable.
    */
   dontWrapText?: boolean;
 } & TokenProps<"Tabs">;
@@ -153,11 +153,12 @@ type CustomTabsContextType = {
   nextButtonShown: boolean;
   setNextButtonShown: React.Dispatch<React.SetStateAction<boolean>>;
   tabPanel: React.RefObject<HTMLDivElement>;
+  scrollable: boolean;
 };
 
 const CustomTabsContext = React.createContext<CustomTabsContextType>({} as CustomTabsContextType);
 
-function useCustomTabsContext(): CustomTabsContextType {
+function useCustomTabsContext(scrollable: boolean): CustomTabsContextType {
   const [prevButtonShown, setPrevButtonShown] = React.useState<boolean>(false);
   const [nextButtonShown, setNextButtonShown] = React.useState<boolean>(true);
 
@@ -192,6 +193,7 @@ function useCustomTabsContext(): CustomTabsContextType {
     nextButtonShown,
     setNextButtonShown,
     tabPanel,
+    scrollable,
   };
 }
 
@@ -205,7 +207,7 @@ function Tabs({
 }: TabsProps) {
   const childrenArray = React.useMemo(() => React.Children.toArray(children) as React.ReactElement[], [children]);
 
-  const tabsContext = useCustomTabsContext();
+  const tabsContext = useCustomTabsContext(scrollButtons);
 
   const tabList = React.useMemo(
     () =>
@@ -357,6 +359,8 @@ function CustomTab({
 }: CustomTabProps) {
   const tokens = useTokens("Tabs", props.tokens);
   const { selectedIndex } = useTabsContext();
+  const { scrollable } = React.useContext(CustomTabsContext);
+
   const { setButtonsVisibility } = React.useContext(CustomTabsContext);
 
   const tab = React.useRef<HTMLDivElement>(null);
@@ -398,7 +402,9 @@ function CustomTab({
     if (onClick) {
       onClick(index);
     }
-    tab.current?.scrollIntoView({ behavior: "smooth", inline: "nearest" });
+    if (scrollable) {
+      tab.current?.scrollIntoView({ behavior: "smooth", inline: "nearest" });
+    }
     setButtonsVisibility(300);
   };
 


### PR DESCRIPTION
## Basic information

* Tiller version: 1.0.1
* Module: form-elements

## Bug description

When using tabs, the focus always shifts to the component when clicking on a certain tab.
This functionality should only occur when scrollable tabs are enabled (most often on mobile devices), not in other use cases.

### Related issue

Closes #11

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
