### PR TITLE
#15 Fix Progress Bar step margin

### DIFF
--- a/libs/core/src/ProgressBar.tsx
+++ b/libs/core/src/ProgressBar.tsx
@@ -139,6 +139,7 @@ export function Step({ active, children, ...props }: StepProps) {
   const stepContainerClassName = cx(
     tokens.stepContainer.master,
     tokens.stepContainer.padding,
+    tokens.stepContainer.margin,
     tokens.stepContainer.fontSize,
     tokens.stepContainer.fontWeight,
     tokens.stepContainer.lineHeight
@@ -168,7 +169,7 @@ export function Step({ active, children, ...props }: StepProps) {
 function RightArrow({ ...props }) {
   const tokens = useTokens("ProgressBar", props.tokens);
   return (
-    <div className="hidden md:block absolute top-0 right-0 h-full w-5">
+    <div className="hidden md:block absolute top-0 right-0 h-full w-1">
       <svg
         className={`h-full w-1 ${tokens.rightArrow.color}`}
         viewBox="0 0 2 72"

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -1253,6 +1253,7 @@ const defaultComponentConfig = {
     stepContainer: {
       master: "flex items-center space-x-4",
       padding: "py-4 px-6",
+      margin: "mr-1",
       fontSize: "text-sm",
       fontWeight: "font-medium",
       lineHeight: "leading-5",


### PR DESCRIPTION
## Basic information

* Tiller version: 1.0.1
* Module: menu

## Bug description

Progress Bar component behaves strange when a lot of steps are defined, margins and padding are off and need to
be adjusted.

### Related issue

Closes #15 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
