### PR TITLE
#26 Fix Icons Import

### DIFF
--- a/libs/icons/src/index.tsx
+++ b/libs/icons/src/index.tsx
@@ -15,7 +15,7 @@
  *
  */
 
-import '../../../node_modules/phosphor-icons/src/css/icons.css';
+import "phosphor-icons/src/css/icons.css";
 
 import {
   IconProps as InternalIconProps,


### PR DESCRIPTION
## Basic information

* Tiller version: 1.0.1
* Module: @tiller-ds/icons

## Description

Change phosphor-icons import path.

### Related issue

Closes #26 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
