### PR TITLE
#46 Move Sidebar Navigation classes to tokens

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-  "trailingComma": "es5",
-  "printWidth": 120,
+  trailingComma: "all",
+  printWidth: 120,
 };

--- a/libs/menu/src/SidebarNavigation.tsx
+++ b/libs/menu/src/SidebarNavigation.tsx
@@ -197,7 +197,7 @@ function SidebarNavigation({
     tokens.container.padding,
     { [tokens.container.dark]: color === "dark" },
     { [tokens.container.light]: color === "light" },
-    { [tokens.container.default]: color === "default" }
+    { [tokens.container.default]: color === "default" },
   );
 
   const navClassName = cx(
@@ -206,7 +206,7 @@ function SidebarNavigation({
     tokens.base.padding,
     { [tokens.base.dark]: color === "dark" },
     { [tokens.base.light]: color === "light" },
-    { [tokens.base.default]: color === "default" }
+    { [tokens.base.default]: color === "default" },
   );
 
   const logoClassName = cx(
@@ -214,7 +214,7 @@ function SidebarNavigation({
     { "hidden md:inline-flex": dropdownOpened },
     { [tokens.logo.withTopRightAction.master]: topRightAction },
     { [tokens.logo.withTopRightAction.margin]: topRightAction },
-    { [tokens.logo.withoutTopRightAction]: !topRightAction }
+    { [tokens.logo.withoutTopRightAction]: !topRightAction },
   );
 
   const bottomActionsClassName = cx(tokens.bottomActions.master, tokens.bottomActions.padding);
@@ -223,7 +223,9 @@ function SidebarNavigation({
 
   const menuButtonClassName = cx(tokens.navButtons.hover);
 
-  const navClass = cx("h-96 flex-col flex-grow", {
+  const menuButtonStyleClassName = cx(tokens.navButtons.margin, tokens.navButtons.size);
+
+  const navClass = cx(tokens.base.container, {
     "md:flex hidden": !isOpen,
     flex: isOpen,
   });
@@ -249,10 +251,15 @@ function SidebarNavigation({
 
   return (
     <div className={containerClassName}>
-      <div className={`grid  grid-cols-3 justify-center`}>
+      <div className={tokens.topContainer}>
         {!dropdownOpened && (
-          <div className="md:hidden flex items-center text-center justify-start md:justify-center">
-            <Button className="ml-4 md:ml-8 h-10" color={menuButtonClassName} variant="text" onClick={handleClick}>
+          <div className={tokens.navButtons.container}>
+            <Button
+              className={menuButtonStyleClassName}
+              color={menuButtonClassName}
+              variant="text"
+              onClick={handleClick}
+            >
               {menuIcon}
             </Button>
           </div>
@@ -304,7 +311,7 @@ export function SidebarNavigationItem({
     { [tokens.item.inactive[color]]: !active },
     { [tokens.item.active[color]]: active },
     { [tokens.item.active.fontWeight]: active },
-    { [tokens.item.expandable.container]: isExpandable }
+    { [tokens.item.expandable.container]: isExpandable },
   );
 
   const iconClassName = cx(tokens.icon.master, tokens.icon.color);
@@ -317,7 +324,7 @@ export function SidebarNavigationItem({
     tokens.item.expandable.subitemsContainer.width,
     { [tokens.item.expandable.subitemsContainer.dark]: color === "dark" },
     { [tokens.item.expandable.subitemsContainer.light]: color === "light" },
-    { [tokens.item.expandable.subitemsContainer.default]: color === "default" }
+    { [tokens.item.expandable.subitemsContainer.default]: color === "default" },
   );
 
   const iconProps = { className: "ml-1 mt-px", size: 3 };
@@ -364,7 +371,7 @@ export function SidebarNavigationDropdown({
   const mobileIconClassName = cx(
     { [dropdownMenutokens.Icon.color.default]: iconColor === "default" },
     { [dropdownMenutokens.Icon.color.dark]: iconColor === "dark" },
-    { [dropdownMenutokens.Icon.color.light]: iconColor === "light" }
+    { [dropdownMenutokens.Icon.color.light]: iconColor === "light" },
   );
 
   const containerClassName = cx(
@@ -372,13 +379,13 @@ export function SidebarNavigationDropdown({
     sidebarNavigationtokens.item.expandable.subitemsContainer.boxShadow,
     { [sidebarNavigationtokens.item.expandable.subitemsContainer.dark]: popupBackgroundColor === "dark" },
     { [sidebarNavigationtokens.item.expandable.subitemsContainer.light]: popupBackgroundColor === "light" },
-    { [sidebarNavigationtokens.item.expandable.subitemsContainer.default]: popupBackgroundColor === "default" }
+    { [sidebarNavigationtokens.item.expandable.subitemsContainer.default]: popupBackgroundColor === "default" },
   );
 
   const dropdownMenuContainerClassName = cx(
     sidebarNavigationtokens.topRightAction.master,
     { "ml-8": !opened },
-    className
+    className,
   );
 
   return (
@@ -427,7 +434,7 @@ export function SidebarNavigationDropdownItem({
     { [tokens.dropdownItem.base.fontWeight]: !active },
     { [tokens.dropdownItem.base[color]]: !active },
     { [tokens.dropdownItem.active[color]]: active },
-    { [tokens.dropdownItem.active.fontWeight]: active }
+    { [tokens.dropdownItem.active.fontWeight]: active },
   );
 
   const iconClassName = cx(tokens.icon.master, tokens.icon.color);

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -1414,8 +1414,10 @@ const defaultComponentConfig = {
       default: "text-white bg-primary-700",
       padding: "py-4 px-3",
     },
+    topContainer: "grid grid-cols-3 justify-center",
     base: {
       master: "flex-col space-y-1 scrollbar overflow-y-auto",
+      container: "h-96 flex-col flex-grow",
       boxShadow: "shadow-sm",
       borderRadius: "rounded-md",
       default: "text-white bg-primary-600",
@@ -1424,6 +1426,9 @@ const defaultComponentConfig = {
       padding: "p-2",
     },
     navButtons: {
+      container: "md:hidden flex items-center text-center justify-start md:justify-center",
+      margin: "ml-4 md:ml-8",
+      size: "h-10",
       hover: "primary",
       master: "hover:text-black",
       default: "text-primary-300",


### PR DESCRIPTION
## Basic information

* Tiller version: 1.1.0
* Module: menu

## Description

Move Sidebar Navigation classes which make sense to be modifiable through tokens to defaultTheme.

### Related issue

Closes #46 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass

