### PR TITLE
#53 Autocomplete - fix inability to remove contained tags

### DIFF
--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -205,7 +205,7 @@ export default function Input({
     { [tokens.inlineLeadingIcon]: inlineLeadingIcon },
     { [tokens.inlineLeadingAddOn]: inlineLeadingAddOn },
     { [tokens.inlineTrailingAddOn]: inlineTrailingAddOn },
-    { [tokens.disabled]: disabled }
+    { [tokens.disabled]: disabled },
   );
 
   const extendedInputClassName = cx(
@@ -216,7 +216,7 @@ export default function Input({
     { [tokens.error.color]: error },
     { [tokens.error.placeholder]: error },
     { [tokens.error.boxShadow]: error },
-    { [tokens.disabled]: disabled }
+    { [tokens.disabled]: disabled },
   );
 
   const inlineTrailingIconClass = cx({
@@ -273,7 +273,7 @@ export default function Input({
           </div>
         )}
       </div>
-      <div className={`absolute inset-y-0 flex ${extend ? "items-start top-3" : "items-center"} right-0`}>
+      <div className={`absolute flex ${extend ? "items-start top-3" : "items-center inset-y-0"} right-0`}>
         {error && <InputIcon icon={finalWarningIcon} inputId={props.id} trailing={true} />}
         {props.value && allowClear && finalClearIcon && <button onClick={onReset}>{finalClearIcon}</button>}
         {inlineTrailingIcon && (
@@ -296,7 +296,7 @@ function InputIcon({ icon, trailing, inputId, ...props }: InputIconProps) {
     "flex pointer-events-auto items-center",
     { [tokens.Icon.color]: !trailing },
     { [tokens.Icon.Container.leading]: !trailing },
-    { [tokens.Icon.Container.trailing]: trailing && !inputId?.includes("downshift") }
+    { [tokens.Icon.Container.trailing]: trailing && !inputId?.includes("downshift") },
   );
   return <div className={className}>{icon}</div>;
 }
@@ -318,14 +318,14 @@ function InputInlineAddOn({ inline, trailing, children, ...props }: InputInlineA
     { "left-0": !trailing },
     { "right-0": trailing },
     { [tokens.addOn.InlineAddOn.leading]: !trailing },
-    { [tokens.addOn.InlineAddOn.trailing]: trailing }
+    { [tokens.addOn.InlineAddOn.trailing]: trailing },
   );
 
   const addOnClassName = cx(
     tokens.addOn.color,
     tokens.addOn.fontSize,
     { [tokens.addOn.inline]: inline },
-    { [tokens.addOn.outline]: !inline }
+    { [tokens.addOn.outline]: !inline },
   );
 
   return (


### PR DESCRIPTION
## Basic information

* Tiller version: 1.2.0
* Module: selectors

## Bug description

On the contained tags variant of Autocomplete some tags (on the right side of the container) cannot be removed because a div is on top of those elements.

### Related issue

Closes #53 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
