### PR TITLE
#58 Move FormLayout classNames to defaultTheme

### DIFF
--- a/libs/form-elements/src/FormLayout.tsx
+++ b/libs/form-elements/src/FormLayout.tsx
@@ -51,6 +51,11 @@ type FormLayoutSectionProps = {
    * Content displayed inside the section.
    */
   children: React.ReactNode;
+
+  /**
+   * Custom container (div) className.
+   */
+  className?: string;
 } & TokenProps<"FormLayout">;
 
 type FormLayoutSectionContentProps = {
@@ -139,7 +144,7 @@ function FormLayout({ children, type = "simple", ...props }: FormLayoutProps) {
   return <FormLayoutContext.Provider value={formLayoutContext}>{result}</FormLayoutContext.Provider>;
 }
 
-export function FormLayoutSection({ title, subtitle, children, ...props }: FormLayoutSectionProps) {
+export function FormLayoutSection({ title, subtitle, children, className, ...props }: FormLayoutSectionProps) {
   const context = React.useContext(FormLayoutContext);
   const tokens = useTokens("FormLayout", props.tokens);
 
@@ -162,7 +167,7 @@ export function FormLayoutSection({ title, subtitle, children, ...props }: FormL
   switch (context?.type ?? "") {
     case "simple":
       return (
-        <div>
+        <div className={className}>
           <div>
             <h2 className={titleClassName}>{title}</h2>
             <h6 className={subtitleClassName}>{subtitle}</h6>

--- a/libs/form-elements/src/FormLayout.tsx
+++ b/libs/form-elements/src/FormLayout.tsx
@@ -164,6 +164,20 @@ export function FormLayoutSection({ title, subtitle, children, className, ...pro
     tokens.subtitle.lineHeight
   );
 
+  const cardTitleClassName = cx(
+    tokens.card.title.fontSize,
+    tokens.card.title.color,
+    tokens.card.title.fontWeight,
+    tokens.card.title.lineHeight,
+  );
+
+  const cardSubtitleClassName = cx(
+    tokens.card.subtitle.fontSize,
+    tokens.card.subtitle.color,
+    tokens.card.subtitle.margin,
+    tokens.card.subtitle.lineHeight,
+  );
+
   switch (context?.type ?? "") {
     case "simple":
       return (
@@ -187,8 +201,8 @@ export function FormLayoutSection({ title, subtitle, children, className, ...pro
         <div className={tokens.card.layout}>
           <div className={tokens.card.titleContainer}>
             <div className={tokens.card.padding}>
-              <h2 className={tokens.card.title}>{title}</h2>
-              <h6 className={tokens.card.subtitle}>{subtitle}</h6>
+              <h2 className={cardTitleClassName}>{title}</h2>
+              <h6 className={cardSubtitleClassName}>{subtitle}</h6>
             </div>
           </div>
           <div className={tokens.card.container}>

--- a/libs/form-elements/src/FormLayout.tsx
+++ b/libs/form-elements/src/FormLayout.tsx
@@ -34,7 +34,7 @@ type FormLayoutProps = {
    * Each type defines the placement of the title, content and/or Card component.
    */
   type?: "simple" | "card" | "full-width";
-};
+} & TokenProps<"FormLayout">;
 
 type FormLayoutSectionProps = {
   /**
@@ -104,7 +104,8 @@ type FormLayoutSectionContext = {
 const FormLayoutContext = createNamedContext<FormLayoutContext>("FormLayoutContext");
 const FormLayoutSectionContext = createNamedContext<FormLayoutSectionContext>("FormLayoutSectionContext");
 
-function FormLayout({ children, type = "simple" }: FormLayoutProps) {
+function FormLayout({ children, type = "simple", ...props }: FormLayoutProps) {
+  const tokens = useTokens("FormLayout", props.tokens);
   const formLayoutContext = React.useMemo(() => ({ type }), [type]);
 
   const childrenArray = React.Children.toArray(children);
@@ -115,15 +116,15 @@ function FormLayout({ children, type = "simple" }: FormLayoutProps) {
       if (type === "card") {
         result.push(
           <div key={i * 2} className="hidden sm:block">
-            <div className="py-5">
-              <div className="border-t border-gray-200">&nbsp;</div>
+            <div className={tokens.borderPadding}>
+              <div className={tokens.border}>&nbsp;</div>
             </div>
           </div>
         );
       }
 
       const className =
-        type === "simple" ? "mt-8 border-t border-gray-200 pt-8" : type === "card" ? "mt-10 sm:mt-0" : "mt-6";
+        type === "simple" ? `${tokens.simpleBorder}` : type === "card" ? "mt-10 sm:mt-0" : "mt-6";
 
       result.push(
         <div key={i * 2 + 1} className={className}>
@@ -178,14 +179,14 @@ export function FormLayoutSection({ title, subtitle, children, ...props }: FormL
         );
       }
       return (
-        <div className="md:grid md:grid-cols-3 md:gap-6">
-          <div className="md:col-span-1">
-            <div className="px-4 sm:px-0">
-              <h2 className="text-lg text-gray-900 font-medium leading-6">{title}</h2>
-              <h6 className="text-sm text-gray-500 mt-1 leading-5">{subtitle}</h6>
+        <div className={tokens.card.layout}>
+          <div className={tokens.card.titleContainer}>
+            <div className={tokens.card.padding}>
+              <h2 className={tokens.card.title}>{title}</h2>
+              <h6 className={tokens.card.subtitle}>{subtitle}</h6>
             </div>
           </div>
-          <div className="mt-5 md:mt-0 md:col-span-2">
+          <div className={tokens.card.container}>
             <Card>{children}</Card>
           </div>
         </div>
@@ -232,12 +233,12 @@ export function FormLayoutSectionContent({ children, ...props }: FormLayoutSecti
   if (context?.type === "full-width" && sectionContext) {
     return (
       <Card.Body {...props}>
-        <div className="md:grid md:grid-cols-3 md:gap-6">
-          <div className="md:col-span-1">
+        <div className={tokens.content.layout}>
+          <div className={tokens.content.titleContainer}>
             <h2 className={titleClassName}>{sectionContext.title}</h2>
             <h6 className={subtitleClassName}>{sectionContext.subtitle}</h6>
           </div>
-          <div className="mt-5 md:mt-0 md:col-span-2 space-y-10">{children}</div>
+          <div className={tokens.content.container}>{children}</div>
         </div>
       </Card.Body>
     );

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -926,6 +926,17 @@ const defaultComponentConfig = {
   },
   FormLayout: {
     backgroundColor: "bg-white",
+    border: "border-t border-gray-200",
+    simpleBorder: "mt-8 border-t border-gray-200 pt-8",
+    borderPadding: "py-5",
+    card: {
+      layout: "md:grid md:grid-cols-3 md:gap-6",
+      titleContainer: "md:col-span-1",
+      title: "text-lg text-gray-900 font-medium leading-6",
+      subtitle: "text-sm text-gray-500 mt-1 leading-5",
+      container: "mt-5 md:mt-0 md:col-span-2",
+      padding: "px-4 sm:px-0",
+    },
     title: {
       fontSize: "text-lg",
       color: "text-gray-900",
@@ -939,6 +950,9 @@ const defaultComponentConfig = {
       lineHeight: "leading-5",
     },
     content: {
+      layout: "md:grid md:grid-cols-3 md:gap-6",
+      titleContainer: "md:col-span-1",
+      container: "mt-5 md:mt-0 md:col-span-2 space-y-10",
       title: {
         fontSize: "text-sm",
         color: "text-gray-500",

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -932,8 +932,18 @@ const defaultComponentConfig = {
     card: {
       layout: "md:grid md:grid-cols-3 md:gap-6",
       titleContainer: "md:col-span-1",
-      title: "text-lg text-gray-900 font-medium leading-6",
-      subtitle: "text-sm text-gray-500 mt-1 leading-5",
+      title: {
+        fontSize: "text-lg",
+        color: "text-gray-900",
+        fontWeight: "font-medium",
+        lineHeight: "leading-6",
+      },
+      subtitle: {
+        fontSize: "text-sm",
+        color: "text-gray-500",
+        margin: "mt-1",
+        lineHeight: "leading-5",
+      },
       container: "mt-5 md:mt-0 md:col-span-2",
       padding: "px-4 sm:px-0",
     },

--- a/storybook/src/form-elements/FormLayout.stories.tsx
+++ b/storybook/src/form-elements/FormLayout.stories.tsx
@@ -106,7 +106,7 @@ function Body({ children }: React.PropsWithChildren<Record<string, unknown>>) {
 }
 
 export default {
-  title: "Component Library/Core/FormLayout",
+  title: "Component Library/Form-elements/FormLayout",
   component: FormLayout,
 
   decorators: [

--- a/storybook/src/menu/SidebarNavigation.mdx
+++ b/storybook/src/menu/SidebarNavigation.mdx
@@ -19,6 +19,11 @@ themed differently via the props sent to the dropdown menu.
 The best possible documentation for this component would be the [Props documentation](#sidebar-navigation-props)
 and the code of the stories listed below.
 
+`Router` in the code examples is actually an alias for the `BrowserRouter` import.
+```ts
+import { BrowserRouter as Router } from "react-router-dom";
+```
+
 <Stories includePrimary={true} />
 
 ## Sidebar Navigation Props:


### PR DESCRIPTION
## Basic information

* Tiller version: 1.2.0
* Module: storybook, form-elements

### Details

Update the SidebarNavigation docs, move FormLayout classes to the defaultTheme, fix placement of the FormLayout in storybook.

### Related issue

Closes #58 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
