### PR TITLE
#65 WIP: Separate components from IntlProvider dependency

### DIFF
--- a/libs/core/src/Pagination.tsx
+++ b/libs/core/src/Pagination.tsx
@@ -19,11 +19,11 @@ import * as React from "react";
 
 import { range, slice } from "lodash";
 
+import { Intl, useIntlContext } from "@tiller-ds/intl";
 import { ComponentTokens, cx, useIcon, useTokens } from "@tiller-ds/theme";
+import { useViewport } from "@tiller-ds/util";
 
 import ButtonGroups from "./ButtonGroups";
-
-import { useViewport } from "@tiller-ds/util";
 
 export type PaginationProps = {
   /**
@@ -32,7 +32,17 @@ export type PaginationProps = {
   children?: (pageInfo: PageInfo, components: Components) => React.ReactNode;
 
   /**
-   * Custom function activated when the page changes (takes the current page as a parameter)
+   * Custom additional class name for the main component.
+   */
+  className?: string;
+
+  /**
+   * Custom icon for going to the next page.
+   */
+  nextIcon?: React.ReactElement;
+
+  /**
+   * Custom function activated when the page changes (takes the current page as a parameter).
    */
   onPageChange?: (page: number) => void;
 
@@ -42,28 +52,29 @@ export type PaginationProps = {
   pageNumber: number;
 
   /**
+   * Defines a calculator for displaying page numbers.
+   */
+  pagerCalculator?: (pageNumber: number, pageCount: number) => PagerPage[];
+
+  /**
+   * Enables or disables the page summary text next to the pagination.
+   */
+  pageSummary?: boolean;
+
+  /**
    * Defines the size of each page (number of shown elements on each page).
    */
   pageSize: number;
 
   /**
+   * Custom icon for going to the previous page.
+   */
+  previousIcon?: React.ReactElement;
+
+  /**
    * Defines the total number of elements on a source that the component is hooked up to.
    */
   totalElements: number;
-
-  /**
-   * Defines a calculator for displaying page numbers.
-   */
-  pagerCalculator?: (pageNumber: number, pageCount: number) => PagerPage[];
-
-  previousIcon?: React.ReactElement;
-
-  nextIcon?: React.ReactElement;
-
-  /**
-   * Custom additional class name for the main component.
-   */
-  className?: string;
 } & PaginationTokensProps;
 
 type PaginationTokensProps = {
@@ -130,7 +141,7 @@ export function useLocalPagination<T>(data: T[], pageSize = 10): [PaginationStat
 }
 
 export default function Pagination(props: PaginationProps) {
-  const { pageNumber, pageSize, totalElements } = props;
+  const { pageNumber, pageSize, totalElements, pageSummary = true } = props;
   const tokens = useTokens("Pagination", props.tokens);
 
   const calculatedProps: CalculatedProps = {
@@ -140,15 +151,17 @@ export default function Pagination(props: PaginationProps) {
 
   return (
     <section className={tokens.master}>
-      <PageSummary {...props} />
+      {pageSummary && <PageSummary {...props} />}
       <Pager {...props} {...calculatedProps} />
     </section>
   );
 }
 
 function PageSummary({ pageNumber, pageSize, totalElements, children, ...props }: PaginationProps) {
-  const calculatedFrom = pageNumber * pageSize;
+  const intl = useIntlContext();
   const tokens = useTokens("Pagination", props.tokens);
+
+  const calculatedFrom = pageNumber * pageSize;
   // user counting starts from 1
   const from = totalElements === 0 ? calculatedFrom : calculatedFrom + 1;
   const to = Math.min(totalElements, (pageNumber + 1) * pageSize);
@@ -162,13 +175,28 @@ function PageSummary({ pageNumber, pageSize, totalElements, children, ...props }
   if (children) {
     return children(
       { pageNumber, pageSize, totalElements, from, to },
-      { from: fromElement, to: toElement, totalElements: totalElement }
+      { from: fromElement, to: toElement, totalElements: totalElement },
     ) as React.ReactElement;
   }
 
   return (
     <p className={pageSummaryClassName}>
-      Showing {fromElement} to {toElement} of {totalElement} results
+      {intl ? (
+        <Intl
+          name={intl.commonKeys["paginationDefault"] ?? "pagination.default"}
+          params={{ from: fromElement, to: toElement, total: totalElement }}
+        >
+          {{
+            from: () => fromElement,
+            to: () => toElement,
+            total: () => totalElement,
+          }}
+        </Intl>
+      ) : (
+        <>
+          Showing {fromElement} to {toElement} of {totalElement} results
+        </>
+      )}
     </p>
   );
 }

--- a/libs/intl/src/IntlProvider.tsx
+++ b/libs/intl/src/IntlProvider.tsx
@@ -31,6 +31,7 @@ export type CommonKeys = {
   autocompleteAddTag?: string;
   autocompleteNoResults?: string;
   selectNoResults?: string;
+  paginationDefault?: string;
 };
 
 type IntlProviderProps = {
@@ -75,11 +76,11 @@ type IntlValue = {
   commonKeys: CommonKeys;
 };
 
-type IntlContext = IntlValue & {
+export type IntlContextType = IntlValue & {
   intl: IntlShape;
 };
 
-export const IntlContext = createNamedContext<IntlContext>("IntlContext");
+export const IntlContext = createNamedContext<IntlContextType>("IntlContext");
 
 export function useIntl(
   language: string,
@@ -91,7 +92,8 @@ export function useIntl(
     autocompleteAddTag: "autocomplete.addTag",
     autocompleteNoResults: "autocomplete.noResults",
     selectNoResults: "select.noResults",
-  }
+    paginationDefault: "pagination.default",
+  },
 ): IntlValue {
   const [lang, setLang] = React.useState<string>(language);
   const [dictionary, setDictionary] = React.useState<Dictionary>(dict || ({} as Dictionary));
@@ -112,7 +114,7 @@ export function useIntl(
         }
       }
     },
-    [loadDictionary]
+    [loadDictionary],
   );
 
   React.useEffect(() => {
@@ -133,7 +135,7 @@ export function useIntl(
       intlUtil: new IntlUtil(dictionary, lang),
       commonKeys: keyConfig,
     }),
-    [lang, dictionary, changeLang]
+    [lang, dictionary, changeLang],
   );
 }
 

--- a/libs/intl/src/index.tsx
+++ b/libs/intl/src/index.tsx
@@ -15,7 +15,7 @@
  *
  */
 
-import { CommonKeys as InternalCommonKeys } from "./IntlProvider";
+import { CommonKeys as InternalCommonKeys, IntlContextType as InternalIntlContextType } from "./IntlProvider";
 
 import {
   Messages as InternalMessages,
@@ -29,8 +29,9 @@ export type Translations = InternalTranslations;
 export type CommonKeys = InternalCommonKeys;
 export type Dictionary = InternalDictionary;
 export type LanguageTranslation = InternalLanguageTranslation;
+export type IntlContextType = InternalIntlContextType;
 
 export { default as Intl } from "./Intl";
-export { default as IntlProvider, useIntl, IntlContext } from "./IntlProvider";
+export { default as IntlProvider, useIntl } from "./IntlProvider";
 export { useIntlContext } from "./useIntlContext";
 export { useLabel } from "./useLabel";

--- a/libs/intl/src/intlDictionary.js
+++ b/libs/intl/src/intlDictionary.js
@@ -5,6 +5,7 @@ export default {
     "autocomplete.addTag": "Add tag:",
     "autocomplete.noResults": "No results for:",
     "select.noResults": "No results",
+    "pagination.default": "Showing {from} to {to} of {total} results",
   },
   translations: {
     hr: {
@@ -13,6 +14,7 @@ export default {
       "autocomplete.addTag": "Dodaj oznaku:",
       "autocomplete.noResults": "Nema rezultata za:",
       "select.noResults": "Nema rezultata",
+      "pagination.default": "Prikazuje se {from} do {to} od {total} rezultata",
     },
     en: {
       required: "Required field",
@@ -20,6 +22,7 @@ export default {
       "autocomplete.addTag": "Add tag:",
       "autocomplete.noResults": "No results for:",
       "select.noResults": "No results",
+      "pagination.default": "Showing {from} to {to} of {total} results",
     },
   },
 };

--- a/libs/intl/src/useIntlContext.tsx
+++ b/libs/intl/src/useIntlContext.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 
-import { IntlContext } from "./IntlProvider";
+import { IntlContext, IntlContextType } from "./IntlProvider";
 
 export function useIntlContext() {
   const context = React.useContext(IntlContext);
 
   if (!context) {
-    throw new Error("useIntlContext must be used within a IntlProvider");
+    return null as unknown as IntlContextType;
   }
 
   return context;

--- a/libs/intl/src/useLabel.tsx
+++ b/libs/intl/src/useLabel.tsx
@@ -22,13 +22,18 @@ import { CommonKeys } from "./IntlProvider";
 import { useIntlContext } from "./useIntlContext";
 
 export function useLabel(name: keyof CommonKeys): string {
-  const { dictionary, lang, commonKeys } = useIntlContext();
+  const intlContext = useIntlContext();
 
-  const key = commonKeys[name] || name;
+  if (intlContext) {
+    const { lang, dictionary, commonKeys } = intlContext;
+    const key = commonKeys[name] || name;
 
-  if (!dictionary?.translations?.[lang]?.[key] && !dictionary?.messages?.[key]) {
-    return defaultDictionary.translations?.[lang]?.[key] || defaultDictionary.messages[name];
+    if (!dictionary?.translations?.[lang]?.[key] && !dictionary?.messages?.[key]) {
+      return defaultDictionary.translations?.[lang]?.[key] || defaultDictionary.messages[name];
+    }
+
+    return (dictionary?.translations?.[lang]?.[key] || dictionary?.messages?.[key]) as string;
   }
 
-  return (dictionary?.translations?.[lang]?.[key] || dictionary?.messages?.[key]) as string;
+  return "Required field";
 }

--- a/storybook/src/intl/Intl.mdx
+++ b/storybook/src/intl/Intl.mdx
@@ -17,7 +17,6 @@ display components which depend on your location.
 **The list of components which require your app to be wrapped inside `Intl Provider`**:
 
 - Amount
-- CheckboxGroup(field)
 - Date
 - DateInput(field)
 - DatePicker
@@ -25,16 +24,10 @@ display components which depend on your location.
 - DateTimeInput(field)
 - TimeInput(field)
 - DragZone(field)
-- Input(field)
 - Login
 - Number
 - NumberInput(field)
-- RadioGroup(field)
 - Select(field)
-- Slider(field)
-- Textarea(field)
-- Toggle(field)
-- TreeSelect(field)
 
 ## Default Intl Dictionary
 


### PR DESCRIPTION
## Basic information

* Tiller version: 1.3.0
* Module: intl

## Description

- exclude IntlProvider as direct dependency for components where possible
- set up defaults for components if IntlProvider is not present

### Related issue

Closes #65

## Types of changes

- Visual improvements (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass

