### PR TITLE
#67 Fix invisible icon on SidebarNavigation expandable item 

### DIFF
--- a/libs/menu/src/SidebarNavigation.tsx
+++ b/libs/menu/src/SidebarNavigation.tsx
@@ -335,6 +335,7 @@ export function SidebarNavigationItem({
     return (
       <div className="cursor-pointer flex flex-col md:items-start items-center">
         <div {...props} className={cn} onClick={() => setOpened(!opened)}>
+          {icon && <div className={iconClassName}>{icon}</div>}
           {title}
           {opened ? closeExpanderIcon : openExpanderIcon}
         </div>


### PR DESCRIPTION
## Basic information

* Tiller version: 1.3.0
* Module: menu

## Bug description

When passing 'icon' prop to an expandable Sidebar Navigation item the icon is not visible next to the item title.
Icon should be visible regardless of the 'isExpandable' prop status.

### Related issue

Closes #67 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
