### PR TITLE
#69 Extend custom items capability to all Autocomplete variants

### DIFF
--- a/libs/intl/src/intlDictionary.js
+++ b/libs/intl/src/intlDictionary.js
@@ -1,23 +1,26 @@
 export default {
   messages: {
     required: "Required field",
-    "autocomplete.noTags": "No tags selected",
+    "autocomplete.addItem": "Add item:",
     "autocomplete.addTag": "Add tag:",
+    "autocomplete.noTags": "No tags selected",
     "autocomplete.noResults": "No results for:",
     "select.noResults": "No results",
   },
   translations: {
     hr: {
       required: "Obavezno polje",
-      "autocomplete.noTags": "Nema odabranih oznaka",
+      "autocomplete.addItem": "Dodaj opciju:",
       "autocomplete.addTag": "Dodaj oznaku:",
+      "autocomplete.noTags": "Nema odabranih oznaka",
       "autocomplete.noResults": "Nema rezultata za:",
       "select.noResults": "Nema rezultata",
     },
     en: {
       required: "Required field",
-      "autocomplete.noTags": "No tags selected",
+      "autocomplete.addItem": "Add item:",
       "autocomplete.addTag": "Add tag:",
+      "autocomplete.noTags": "No tags selected",
       "autocomplete.noResults": "No results for:",
       "select.noResults": "No results",
     },

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -49,12 +49,6 @@ export type AutocompleteProps<T extends {}> = {
    */
   error?: React.ReactNode;
   /**
-   * For fetching an array of options from backend (async) or by passing an array of options.
-   * Important: if passing an array the filter prop must also be defined, otherwise filtering while typing will not work.
-   */
-  options: ((query: string) => Promise<T[]>) | T[];
-
-  /**
    * Function that defines filtering of the options on the frontend.
    * Needs to be enabled if an array is given to the component via options prop instead of an async fetch!
    * Useful for seamless filtering without loading animations, since all the work is done on frontend.
@@ -62,6 +56,36 @@ export type AutocompleteProps<T extends {}> = {
    * Example: (name: string, option) => option.name.toLowerCase().includes(name.toLowerCase())
    */
   filter?: (query: string, item: T) => boolean;
+  /**
+   * Function for determining the look of the offered custom item when typing inside the component.
+   *
+   * Gives the component **ability to add custom items** and show them in the popup display.
+   * Return value of this prop also determines the shape of the item handed over by _onAddCustomItem_ prop.
+   *
+   * When adding custom items, the color of added items will be the secondary color from your config.
+   *
+   * **Note**: Persisting custom options inside the component is not possible if _onAddCustomItem_ prop is not used alongside this one.
+   *
+   * @component
+   * @example adding a prefix to tags
+   * getCustomItem = {(tag: string) => ("#" + tag)}
+   *
+   * @component
+   * @example working with complex types
+   * getCustomItem = {(tag: string) => {
+   *                 const name = tag.split(" ")[0];
+   *                 const surname = tag.split(" ")[1];
+   *                 const item: Item = {
+   *                   name: name,
+   *                   surname: surname ?? "",
+   *                   username: surname
+   *                     ? tag[0].toLowerCase() + surname.toLowerCase()
+   *                     : tag[0].toLowerCase() ?? "",
+   *                 };
+   *                 return item;
+   *               }}
+   */
+  getCustomItem?: (item: string) => T;
   /**
    * Function that determines the output of selected values on field.
    * Return value is string(!) as opposed to React.ReactNode on SelectField.
@@ -102,7 +126,7 @@ export type AutocompleteProps<T extends {}> = {
   help?: React.ReactNode;
   /**
    * Function determining what property of an item (selected from a dropdown list) is shown in the menu and
-   * what property of an item is shown when the item is chosen (if 'allowMultiple' is not enabled).
+   * what property of an item is shown when the item is chosen (if 'allowMultiple' is disabled).
    * If you wish to show a more complex display of an item in the menu, use 'getOptionLabel' instead or alongside this prop
    * (depending on the 'allowMultiple' prop).
    * Note: this prop is required when 'allowMultiple' is not enabled (because it's required to
@@ -125,23 +149,16 @@ export type AutocompleteProps<T extends {}> = {
    */
   name: string;
   /**
-   * Function determining the output of added tag. Useful if you want to add a prefix to tags (for example '#') or
-   * create an object to be added (if working with complex types - possible from v2.2.2).
-   * The color of custom added badges will be colored with 'secondary' color from your config.
-   * NOTE: Adding new tags is not possible if this prop is not enabled.
-   * Example 1 - working with strings: (tag: string) => ("#" + tag)
-   * Example 2 - working with complex types: (tag: string) => {
-   *                 const item: Item = {
-   *                   name: tag.split(" ")[0],
-   *                   surname: tag.split(" ")[1] ?? "",
-   *                   username: tag.split(" ")[1]
-   *                     ? tag[0].toLowerCase() + tag.split(" ")[1].toLowerCase()
-   *                     : tag[0].toLowerCase() ?? "",
-   *                 };
-   *                 return item;
-   *               }
+   * Enables the possibility of persisting custom items inside the component by allowing you to execute the desired action
+   * (e.g. call to backend or setting state) once a new custom item has been added.
+   *
+   * The item handed over by this function has the shape of the item returned by _getCustomItem_ prop.
+   *
+   * Without defining the logic for persistence here new custom items only stay inside the component until they are unselected.
+   *
+   * **Note**: this prop should be used alongside the _getCustomItem_ prop.
    */
-  onAddCustomTag?: (item: string) => T;
+  onAddCustomItem?: (item: T) => void;
   /**
    * Defines the behaviour of the component once the focus shifts away from the component.
    */
@@ -154,6 +171,11 @@ export type AutocompleteProps<T extends {}> = {
    * Defines the behaviour of the component once the state resets.
    */
   onReset?: () => void;
+  /**
+   * For fetching an array of options from backend (async) or by passing an array of options.
+   * Important: if passing an array the filter prop must also be defined, otherwise filtering while typing will not work.
+   */
+  options: ((query: string) => Promise<T[]>) | T[];
   /**
    * The placeholder displayed inside the text input field.
    */
@@ -217,7 +239,8 @@ function Autocomplete<T extends {}>({
   sort,
   tags,
   tagsContained,
-  onAddCustomTag,
+  getCustomItem,
+  onAddCustomItem = () => null,
   onReset,
   onBlur,
   disabled,
@@ -228,7 +251,7 @@ function Autocomplete<T extends {}>({
 }: AutocompleteProps<T>) {
   const autocompleteTokens = useTokens("Autocomplete", props.autocompleteTokens);
   const selectTokens = useTokens("Select", props.selectTokens);
-  const selectedIcon = useIcon("completed", undefined, { className: "text-primary" });
+  const selectedIcon = useIcon("completed", undefined);
   const loadingIcon = useIcon("loading", undefined, { size: 3 });
   const searchIcon = useIcon("search", undefined, { size: 4 });
   const openExpanderIcon = useIcon("openExpander", undefined, { size: 3 });
@@ -241,8 +264,8 @@ function Autocomplete<T extends {}>({
   const menuRef = React.useRef<HTMLElement>(null);
 
   const [loading, setLoading] = React.useState(false);
-  const [customTags, setCustomTags] = React.useState<T[]>([]);
 
+  const [customOptions, setCustomOptions] = React.useState<T[]>([]);
   const [filteredOptions, setFilteredOptions] = React.useState<T[]>([]);
   const [selectedOptions, setSelectedOptions] = React.useState<T[]>(Array.isArray(value) && allowMultiple ? value : []);
 
@@ -333,6 +356,10 @@ function Autocomplete<T extends {}>({
       if (selectionTypes.indexOf(type) !== -1 && !allowMultiple) {
         if (selectedItem !== undefined && selectedItem !== null) {
           onChange(selectedItem);
+          if (getCustomItem && !customOptions.includes(selectedItem)) {
+            setCustomOptions([...customOptions, selectedItem]);
+            onAddCustomItem(selectedItem);
+          }
         } else {
           const stringOptions = filteredOptions.map((option) => safeItemToString(option).toLowerCase());
           if (stringOptions.includes(inputValue.toLowerCase())) {
@@ -355,6 +382,7 @@ function Autocomplete<T extends {}>({
     if (allowMultiple) {
       setInputValue("");
     }
+    setLoading(false);
   };
 
   const isEmpty = React.useRef(!!initialInputValue);
@@ -404,22 +432,25 @@ function Autocomplete<T extends {}>({
         setLoading(true);
         loadOptions(inputValue)
           .then((response) => {
+            const uniqueResponse = Array.from(new Set(response));
             if (!cancelled) {
               setLoading(false);
               if (mounted.current && !tags && !inputValue) {
-                setFilteredOptions(selectedToTop(response, selectedOptions));
+                setFilteredOptions(selectedToTop(uniqueResponse, selectedOptions));
               } else if (inputValue) {
-                if (tags && onAddCustomTag) {
+                if (getCustomItem) {
                   setFilteredOptions(
-                    getDifference([...response, ...Array.of(onAddCustomTag(inputValue))], selectedOptions),
+                    tags
+                      ? getDifference([...uniqueResponse, ...Array.of(getCustomItem(inputValue))], selectedOptions)
+                      : [...uniqueResponse, ...Array.of(getCustomItem(inputValue))],
                   );
                 } else {
-                  setFilteredOptions(response);
+                  setFilteredOptions(uniqueResponse);
                 }
               } else if (tags && mounted.current) {
-                setFilteredOptions(removeSelected(response));
+                setFilteredOptions(removeSelected(uniqueResponse));
               } else {
-                setFilteredOptions(selectedToTop(response, selectedOptions));
+                setFilteredOptions(selectedToTop(uniqueResponse, selectedOptions));
               }
             }
           })
@@ -435,7 +466,7 @@ function Autocomplete<T extends {}>({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [options, inputValue, sort, isOpen, tags, onAddCustomTag]);
+  }, [options, inputValue, sort, isOpen, tags, getCustomItem]);
 
   const lastValue = React.useRef<T | T[] | null | undefined>();
   React.useEffect(() => {
@@ -515,18 +546,20 @@ function Autocomplete<T extends {}>({
     selectTokens.Item.base.color,
   );
 
-  const itemClassName = (bold: boolean, selected: boolean) =>
+  const itemClassName = (bold: boolean, selected: boolean, custom: boolean) =>
     cx(
       autocompleteTokens.Item.base.regular,
-      { [autocompleteTokens.Item.base.selected]: selected },
+      { [autocompleteTokens.Item.base.selected]: selected && !custom },
+      { [autocompleteTokens.Item.base.selectedCustom]: selected && custom },
       { [autocompleteTokens.Item.accentuated]: bold },
     );
 
-  const activeClassName = (bold: boolean, selected: boolean, hovered: boolean) =>
+  const activeClassName = (bold: boolean, selected: boolean, hovered: boolean, custom: boolean) =>
     cx(
       autocompleteTokens.Item.active.regular,
       { [autocompleteTokens.Item.active.selected]: selected },
-      { [autocompleteTokens.Item.active.hovered]: selected && hovered },
+      { [autocompleteTokens.Item.active.hovered]: selected && hovered && !custom },
+      { [autocompleteTokens.Item.active.hoveredCustom]: selected && hovered && custom },
       { [autocompleteTokens.Item.accentuated]: bold },
     );
 
@@ -549,16 +582,11 @@ function Autocomplete<T extends {}>({
     "bg-white",
   );
 
-  const tagPlaceholderClassName = cx({
-    "h-6 mt-2 ml-2 text-gray-500": true,
-    "text-small": true,
-    "text-body": true,
-  });
-
-  const tagExists = () =>
-    filteredOptions.length > 1 && onAddCustomTag
-      ? getDifference(filteredOptions, Array.of(onAddCustomTag(inputValue))).length === 0
-      : !onAddCustomTag;
+  const tagPlaceholderClassName = cx(
+    autocompleteTokens.tagPlaceholder.master,
+    autocompleteTokens.tagPlaceholder.fontSize,
+    autocompleteTokens.tagPlaceholder.textColor,
+  );
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     const nativeEvent = event.nativeEvent as any;
@@ -569,13 +597,17 @@ function Autocomplete<T extends {}>({
 
     if (allowMultiple && event.key === "Enter" && highlightedOption !== undefined) {
       nativeEvent.preventDownshiftDefault = true;
-      checkItem(-1, !tagExists() && highlightedIndex === filteredOptions.length - 1);
+      checkItem(-1,
+        inputValue.length > 0 &&
+          getCustomItem &&
+          getDifference(filteredOptions, Array.of(getCustomItem(inputValue))).length === 0,
+      );
     }
   };
 
-  const onItemClick = (event: React.MouseEvent, index: number, customTag?: boolean) => {
+  const onItemClick = (event: React.MouseEvent, index: number, customItem?: boolean) => {
     event.nativeEvent.preventDefault();
-    checkItem(index, customTag);
+    checkItem(index, customItem);
   };
 
   const removeSelected = (array: T[]) => {
@@ -598,7 +630,7 @@ function Autocomplete<T extends {}>({
     }
   };
 
-  const checkItem = (index: number, customTag?: boolean) => {
+  const checkItem = (index: number, customItem?: boolean) => {
     const selectedOption = filteredOptions[index] || highlightedOption;
     if (allowMultiple && (highlightedOption || index > -1)) {
       if (getOptionValue) {
@@ -608,8 +640,9 @@ function Autocomplete<T extends {}>({
           );
           setSelectedOptions(filteredOptions);
         } else {
-          if (customTag) {
-            setCustomTags([...customTags, selectedOption]);
+          if (customItem) {
+            setCustomOptions([...customOptions, selectedOption]);
+            onAddCustomItem(selectedOption);
           }
           setSelectedOptions([...selectedOptions, selectedOption]);
         }
@@ -617,12 +650,13 @@ function Autocomplete<T extends {}>({
         const filteredOptions = selectedOptions.filter((option) => !(option === selectedOption));
         setSelectedOptions(filteredOptions);
       } else {
-        if (customTag) {
-          setCustomTags([...customTags, selectedOption]);
+        if (customItem) {
+          setCustomOptions([...customOptions, selectedOption]);
+          onAddCustomItem(selectedOption);
         }
         setSelectedOptions([...selectedOptions, selectedOption]);
       }
-      if (tags && inputValue) {
+      if (customItem) {
         mounted.current = true;
         reorderOptions();
         setInputValue("");
@@ -689,17 +723,19 @@ function Autocomplete<T extends {}>({
 
   const SelectItems = () => {
     const lastIndex = allowMultiple ? filteredOptions.length : maxItems;
-    if (onAddCustomTag) {
+    if (getCustomItem) {
       return (
         <>
           {filteredOptions
-            .slice(0, lastIndex)
+            .slice(0, lastIndex === 0 && getCustomItem ? 1 : lastIndex)
             .map((option, index) =>
               !inputValue || index !== filteredOptions.length - 1 ? (
                 <SelectItem key={index} index={index} option={option} />
               ) : (
                 inputValue &&
-                !tagExists() && <SelectItem key={index} tag={true} option={onAddCustomTag(inputValue)} index={index} />
+                !arrayIncludes(filteredOptions.slice(0, filteredOptions.length - 1), getCustomItem(inputValue)) && (
+                  <SelectItem key={index} custom={true} option={getCustomItem(inputValue)} index={index} />
+                )
               ),
             )}
         </>
@@ -714,7 +750,7 @@ function Autocomplete<T extends {}>({
     );
   };
 
-  const SelectItem = ({ option, index, tag }: { option: T; index: number; tag?: boolean }) => {
+  const SelectItem = ({ option, index, custom }: { option: T; index: number; custom?: boolean }) => {
     const label = safeItemToString(option);
     const checkFirstChar = label.toLowerCase()[0] === inputValue?.toLowerCase()[0];
     const checkFirstWord = label.split(" ")[0].toLowerCase().includes(inputValue.split(" ")[0].toLowerCase());
@@ -730,6 +766,10 @@ function Autocomplete<T extends {}>({
       : selectedOptions.includes(option);
     const hovered = highlightedIndex === index;
 
+    const customContains = customOptions.includes(option);
+    const selectedIconClassName = !customContains ? "text-primary" : "text-secondary";
+    const finalSelectedIcon = React.cloneElement(selectedIcon, { className: selectedIconClassName });
+
     const contentWrapper = (children: React.ReactNode, tag?: boolean) => {
       return (
         <div
@@ -741,19 +781,18 @@ function Autocomplete<T extends {}>({
           })}
           className={
             highlightedIndex === index
-              ? activeClassName(!getOptionLabel ? !tag && boldAll : false, selected, hovered)
-              : itemClassName(!getOptionLabel ? !tag && boldAll : false, selected)
+              ? activeClassName(!getOptionLabel ? !tag && boldAll : false, selected, hovered, customContains)
+              : itemClassName(!getOptionLabel ? !tag && boldAll : false, selected, customContains)
           }
         >
           {children}
         </div>
       );
     };
-
-    return (
-      <>
-        {(selected || inputValue) && !getOptionLabel
-          ? !tag
+    if ((selected || inputValue) && !getOptionLabel) {
+      return (
+        <>
+          {!custom
             ? contentWrapper(
                 <>
                   <div className="truncate w-10/12">
@@ -762,29 +801,38 @@ function Autocomplete<T extends {}>({
                       {label.substring(inputValue?.length)}
                     </span>
                   </div>
-                  {allowMultiple && selected && selectedIcon}
+                  {allowMultiple && selected && finalSelectedIcon}
                 </>,
               )
-            : onAddCustomTag &&
+            : getCustomItem &&
               contentWrapper(
                 <>
-                  <Intl name="autocomplete.addTag" /> {""}
-                  <Badge color="secondary" dot={true} small={true}>
-                    {safeItemToString(onAddCustomTag(inputValue))}
-                  </Badge>
+                  <Intl name={tags ? "autocomplete.addTag" : "autocomplete.addItem"} /> {""}
+                  {tags ? (
+                    <Badge color="secondary" dot={true} small={true}>
+                      {safeItemToString(getCustomItem(inputValue))}
+                    </Badge>
+                  ) : (
+                    <span className="font-bold">{safeItemToString(getCustomItem(inputValue))}</span>
+                  )}
                 </>,
                 true,
-              )
-          : contentWrapper(
-              <div className={autocompleteTokens.Item.complex.container}>
-                <div className={autocompleteTokens.Item.complex.element}>
-                  {getOptionLabel ? optionLabelFn(option) : safeItemToString(option)}
-                </div>
-                {allowMultiple && <div className={complexSelectedClassName}>{selected && selectedIcon}</div>}
-              </div>,
-            )}
-      </>
-    );
+              )}
+        </>
+      );
+    } else
+      return (
+        <>
+          {contentWrapper(
+            <div className={autocompleteTokens.Item.complex.container}>
+              <div className={autocompleteTokens.Item.complex.element}>
+                {getOptionLabel ? optionLabelFn(option) : safeItemToString(option)}
+              </div>
+              {allowMultiple && <div className={complexSelectedClassName}>{selected && finalSelectedIcon}</div>}
+            </div>,
+          )}
+        </>
+      );
   };
 
   const content =
@@ -810,7 +858,7 @@ function Autocomplete<T extends {}>({
             <Badge
               key={key}
               dot={true}
-              color={!arrayIncludes(customTags, v) ? "primary" : "secondary"}
+              color={!arrayIncludes(customOptions, v) ? "primary" : "secondary"}
               onRemoveButtonClick={() => {
                 const filtered = selectedOptions.filter((toFilter) => {
                   if (getOptionValue) {

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -53,7 +53,9 @@ export type AutocompleteProps<T extends {}> = {
    * Needs to be enabled if an array is given to the component via options prop instead of an async fetch!
    * Useful for seamless filtering without loading animations, since all the work is done on frontend.
    * Set as a function that compares each option from the dataset with the user's input.
-   * Example: (name: string, option) => option.name.toLowerCase().includes(name.toLowerCase())
+   *
+   * @example
+   * filter = {(name: string, option) => option.name.toLowerCase().includes(name.toLowerCase())}
    */
   filter?: (query: string, item: T) => boolean;
   /**
@@ -90,34 +92,44 @@ export type AutocompleteProps<T extends {}> = {
    * Function that determines the output of selected values on field.
    * Return value is string(!) as opposed to React.ReactNode on SelectField.
    * Default behaviour: shows number of selected items if the number is larger than 1.
-   * Example 1: (items: Item[]) => (items.map(item => `${item.name} ${item.surname}`).join(", "))
    *
-   * Example 2: (items: Item[]) => (`${items.length} values selected`)
+   * @example with values
+   * getMultipleSelectedLabel = {(items: Item[]) => (items.map(item => `${item.name} ${item.surname}`).join(", "))}
+   *
+   * @example with number of values
+   * getMultipleSelectedLabel = {(items: Item[]) => (`${items.length} values selected`)}
    */
   getMultipleSelectedLabel?: (array: T[]) => string;
   /**
    * Function determining how the item will be displayed in the dropdown menu (not exclusively text).
+   *
    * If you wish to have the same display in the menu as the display in the field then this prop is not required,
    * 'itemToString' is sufficient. Define this prop only if you wish to have a complex display in the menu.
+   *
    * Defining this prop removes bolding of the matched text in the menu since the component always
    * uses this prop to show the items in the menu (you can use this prop instead of 'itemToString' if
    * 'allowMultiple' is not enabled, otherwise you must use it alongside 'itemToString').
-   * Note: this prop is not compatible with 'tags' prop because tags variant requires 'itemToString' prop to display items in a badge.
-   * Example: (item: Item) => (
+   *
+   * **Note**: this prop is not compatible with 'tags' prop because tags variant requires 'itemToString' prop to display items in a badge.
+   *
+   * @example
+   * getOptionLabel = {(item: Item) => {(
    *     <div className="flex items-center justify-between flex-wrap">
    *       <div>
    *         {item.name} {item.surname}
    *       </div>
    *       <div className="flex-shrink-0 text-sm leading-5 text-gray-500">@{item.username}</div>
    *     </div>
-   *   )
+   *   )}
    */
   getOptionLabel?: (item: T) => React.ReactNode;
   /**
    * Function describing what property of the object the component will treat as a value. Required because
    * comparison between objects requires a unique value (typically id) to properly compare two objects
    * from different arrays.
-   * Ex. (item: Item) => item.id
+   *
+   * @example
+   * getOptionValue = {(item: Item) => item.id}
    */
   getOptionValue?: (item: T) => unknown;
   /**
@@ -129,9 +141,12 @@ export type AutocompleteProps<T extends {}> = {
    * what property of an item is shown when the item is chosen (if 'allowMultiple' is disabled).
    * If you wish to show a more complex display of an item in the menu, use 'getOptionLabel' instead or alongside this prop
    * (depending on the 'allowMultiple' prop).
-   * Note: this prop is required when 'allowMultiple' is not enabled (because it's required to
+   *
+   * **Note**: this prop is required when 'allowMultiple' is not enabled (because it's required to
    * set the value of the input field on item selection) and when 'tags' prop is enabled (in order to display the item in a badge).
-   * Example: (item: Item) => `${item.name} ${item.surname}`
+   *
+   * @example
+   * itemToString = {(item: Item) => `${item.name} ${item.surname}`}
    */
   itemToString?: (item: T) => string;
   /**
@@ -141,6 +156,7 @@ export type AutocompleteProps<T extends {}> = {
   /**
    * Determines the maximum number of displayed options displayed as a dropdown list when the component is clicked.
    * For displaying all content, set this value to the length of the content array.
+   *
    * When multiple selection is enabled, this value is automatically set to the content length for ease of use.
    */
   maxItems?: number;
@@ -173,7 +189,8 @@ export type AutocompleteProps<T extends {}> = {
   onReset?: () => void;
   /**
    * For fetching an array of options from backend (async) or by passing an array of options.
-   * Important: if passing an array the filter prop must also be defined, otherwise filtering while typing will not work.
+   *
+   * **Important**: if passing an array the filter prop must also be defined, otherwise filtering while typing will not work.
    */
   options: ((query: string) => Promise<T[]>) | T[];
   /**
@@ -186,9 +203,13 @@ export type AutocompleteProps<T extends {}> = {
    */
   required?: boolean;
   /**
-   * Function representing how the component handles the displayed array of items. Most often something similar to items.sort((a, b) => a.name.localeCompare(b.name))
+   * Function representing how the component handles the displayed array of items.
    * Turned off by default because of generic types, but recommended to use for intuitiveness.
+   *
    * When working with tags the badges displayed below the field are not sorted.
+   *
+   * @example
+   * sort = {(items: Item[]) => items.sort((a, b) => a.name.localeCompare(b.name))}
    */
   sort?: (items: T[]) => T[];
   /**
@@ -198,7 +219,8 @@ export type AutocompleteProps<T extends {}> = {
 
   /**
    * Toggle for transforming the field into a multiselect field with tags.
-   * NOTE: Requires 'allowMultiple' and 'itemToString' (for displaying text inside the tag) props in order to work.
+   *
+   * **Note**: Requires 'allowMultiple' and 'itemToString' (for displaying text inside the tag) props in order to work.
    */
   tags?: boolean;
 
@@ -597,7 +619,8 @@ function Autocomplete<T extends {}>({
 
     if (allowMultiple && event.key === "Enter" && highlightedOption !== undefined) {
       nativeEvent.preventDownshiftDefault = true;
-      checkItem(-1,
+      checkItem(
+        -1,
         inputValue.length > 0 &&
           getCustomItem &&
           getDifference(filteredOptions, Array.of(getCustomItem(inputValue))).length === 0,

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -175,6 +175,15 @@ export type AutocompleteProps<T extends {}> = {
    * **Note**: this prop should be used alongside the _getCustomItem_ prop.
    */
   onAddCustomItem?: (item: T) => void;
+
+  /**
+   * **DEPRECATED.**
+   *
+   * Replaced with _onAddCustomItem_ (which is more flexible), but still usable for tags.
+   *
+   * **Do not** use alongside _onAddCustomItem_.
+   */
+  onAddCustomTag?: (item: T) => void;
   /**
    * Defines the behaviour of the component once the focus shifts away from the component.
    */
@@ -263,6 +272,7 @@ function Autocomplete<T extends {}>({
   tagsContained,
   getCustomItem,
   onAddCustomItem = () => null,
+  onAddCustomTag = () => null,
   onReset,
   onBlur,
   disabled,
@@ -381,6 +391,7 @@ function Autocomplete<T extends {}>({
           if (getCustomItem && !customOptions.includes(selectedItem)) {
             setCustomOptions([...customOptions, selectedItem]);
             onAddCustomItem(selectedItem);
+            if (tags) onAddCustomTag(selectedItem);
           }
         } else {
           const stringOptions = filteredOptions.map((option) => safeItemToString(option).toLowerCase());
@@ -666,6 +677,7 @@ function Autocomplete<T extends {}>({
           if (customItem) {
             setCustomOptions([...customOptions, selectedOption]);
             onAddCustomItem(selectedOption);
+            if (tags) onAddCustomTag(selectedOption);
           }
           setSelectedOptions([...selectedOptions, selectedOption]);
         }
@@ -676,6 +688,7 @@ function Autocomplete<T extends {}>({
         if (customItem) {
           setCustomOptions([...customOptions, selectedOption]);
           onAddCustomItem(selectedOption);
+          if (tags) onAddCustomTag(selectedOption);
         }
         setSelectedOptions([...selectedOptions, selectedOption]);
       }

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -99,12 +99,14 @@ const defaultComponentConfig = {
         regular:
           "w-full text-sm px-4 py-2 block leading-5 cursor-pointer text-slate-700 hover:text-slate-900 hover:bg-slate-100 focus:outline-none focus:text-slate-900 focus:bg-slate-100 truncate",
         selected: "flex items-center justify-between bg-primary-50",
+        selectedCustom: "flex items-center justify-between bg-secondary-50",
       },
       active: {
         regular:
           "w-full text-sm px-4 py-2 block leading-5 cursor-pointer text-slate-900 bg-slate-100 focus:outline-none truncate",
         selected: "flex justify-between items-center",
         hovered: "bg-primary-light",
+        hoveredCustom: "bg-secondary-light",
       },
       accentuated: "font-bold",
       complex: {
@@ -162,6 +164,11 @@ const defaultComponentConfig = {
       fontSize: "text-sm",
       lineHeight: "leading-5",
       color: "text-slate-700",
+    },
+    tagPlaceholder: {
+      master: "h-6 mt-2 ml-2",
+      fontSize: "text-base",
+      textColor: "text-body",
     },
   },
   Badge: {

--- a/storybook/src/formik-elements/AutocompleteField.mdx
+++ b/storybook/src/formik-elements/AutocompleteField.mdx
@@ -4,8 +4,7 @@ import { AutocompleteField } from "@tiller-ds/formik-elements";
 import { Autocomplete } from "@tiller-ds/selectors";
 import { ThemeTokens } from "../utils";
 
-
-<Meta title="Docs|AutocompleteField" component={ AutocompleteField } />
+<Meta title="Docs|AutocompleteField" component={AutocompleteField} />
 
 # Autocomplete Field
 
@@ -28,10 +27,10 @@ using **controls**.
 To create your custom Autocomplete Field component:
 
 - Switch to the `Canvas` section of the Storybook and navigate to `Autocomplete Field Factory` story
-of the Autocomplete Field.
+  of the Autocomplete Field.
 - Modify props using controls.
 - When you're happy with what you've created, switch back to the `Docs` section, and you will be automatically
-navigated to your created Autocomplete Field.
+  navigated to your created Autocomplete Field.
 - After you click the `Show code` button below your custom Autocomplete Field, the code of the Autocomplete Field will be generated.
 
 ### Result:
@@ -55,7 +54,6 @@ export type Item = {
   surname: string;
 };
 ```
-
 
 ## Used Props
 
@@ -94,23 +92,23 @@ const complexProps = {
 const backendProps = {
   ...commonProps,
   options: (query: string) =>
-  promiseTimeout(
-    Promise.resolve(
-      query.length > 0
-      ? items.filter(
-      (item) =>
-      item.name.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.surname.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.username.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.name
-      .concat(" " + item.surname)
-      .toLowerCase()
-      .indexOf(query.toLowerCase()) !== -1
-      )
-      : items
+    promiseTimeout(
+      Promise.resolve(
+        query.length > 0
+          ? items.filter(
+              (item) =>
+                item.name.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.surname.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.username.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.name
+                  .concat(" " + item.surname)
+                  .toLowerCase()
+                  .indexOf(query.toLowerCase()) !== -1,
+            )
+          : items,
+      ),
+      500,
     ),
-    500
-  ),
   getOptionValue: (item: Item) => item.username,
 };
 ```
@@ -119,20 +117,20 @@ const backendProps = {
 const backendSimpleProps = {
   ...commonSimpleProps,
   options: (query: string) =>
-  promiseTimeout(
-    Promise.resolve(
-      query.length > 0
-      ? simpleItems.filter(
-      (item) =>
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1
-      )
-      : simpleItems
+    promiseTimeout(
+      Promise.resolve(
+        query.length > 0
+          ? simpleItems.filter(
+              (item) =>
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1,
+            )
+          : simpleItems,
+      ),
+      500,
     ),
-    500
-  ),
 };
 ```
 
@@ -142,12 +140,12 @@ const frontendProps = {
   options: items,
   getOptionValue: (item: Item) => item.username,
   filter: (name: string, option) =>
-  (option.name.toLowerCase() + " " + option.surname.toLowerCase()).includes(name.toLowerCase()),
+    (option.name.toLowerCase() + " " + option.surname.toLowerCase()).includes(name.toLowerCase()),
 };
 ```
 
 ```ts
-  const frontendSimpleProps = {
+const frontendSimpleProps = {
   ...commonSimpleProps,
   options: simpleItems,
   filter: (name: string, option) => (option.toLowerCase() + " " + option.toLowerCase()).includes(name.toLowerCase()),
@@ -240,45 +238,6 @@ inside the field instead of a counter shown by default.
   <Story id="component-library-formik-elements-autocompletefield--with-multiple-selection-and-visible-labels" />
 </Canvas>
 
-## **(NEW) With Tags**
-
-By enabling the `tags` prop, the look and feel of autocomplete field changes in order to accompany the display of selected
-items as tags below the field. This gives you the ability to visualize selected items more explicitly and easily remove
-selected tags or add new tags. <br />
-It is recommended to use this variant with non-complex types (strings), but the usage with complex types is also possible.
-**Note**: `tags` prop requires `allowMultiple` prop to also be enabled in order to function.
-
-<Canvas>
-  <Story id="component-library-formik-elements-autocompletefield--with-tags" />
-</Canvas>
-
-You can also use complex values for tags, but be careful because this is a bit more complicated to implement due to the nature of objects.
-Make sure you secure your `onAddCustomTag` function if you wish to have this option enabled when using complex types.
-The example below represents the secured usage of this function, no matter the input value.
-
-<Canvas>
-  <Story id="component-library-formik-elements-autocompletefield--with-complex-tags" />
-</Canvas>
-
-## **(NEW) With Contained Tags**
-
-Another variant for displaying tags is achieved by turning on the `tagsContained` prop. By doing this, the look and feel
-of the component changes to a more contained one as tags are put inside the field itself.
-
-<Canvas>
-  <Story id="component-library-formik-elements-autocompletefield--with-contained-tags" />
-</Canvas>
-
-## **(NEW) With Complex Tags**
-
-You can also pass complex objects as tags, there's no restriction to simple types. The `onAddCustomTag` prop takes care of how your newly added props will
-be saved. See the description of `onAddCustomTag` prop in the [AutocompleteField Props section](#autocompletefield-props)
-of the documentation for best explanation of its usage.
-
-<Canvas>
-  <Story id="component-library-formik-elements-autocompletefield--with-complex-tags" />
-</Canvas>
-
 ## With Filtering on Frontend
 
 If you enable filtering on the frontend you will experience **faster responses without loading animations** because
@@ -292,12 +251,74 @@ but it's important to define the filtering method on the frontend with the `filt
   <Story id="component-library-formik-elements-autocompletefield--with-filtering-on-frontend" />
 </Canvas>
 
+## With Tags
+
+By enabling the `tags` prop, the look and feel of autocomplete field changes in order to accompany the display of selected
+items as tags below the field. This gives you the ability to visualize selected items more explicitly and easily remove
+selected tags or add new tags. <br />
+It is recommended to use this variant with non-complex types (strings), but the usage with complex types is also possible.
+**Note**: `tags` prop requires `allowMultiple` prop to also be enabled in order to function.
+
+<Canvas>
+  <Story id="component-library-formik-elements-autocompletefield--with-tags" />
+</Canvas>
+
+You can also use complex values for tags, but be careful because this is a bit more complicated to implement due to the nature of objects.
+Make sure you secure your _getCustomItem_ and _onAddCustomItem_ functions if you wish to have this option enabled when using complex types.
+The example below represents the secured usage of this function, no matter the input value.
+
+<Canvas>
+  <Story id="component-library-formik-elements-autocompletefield--with-complex-tags" />
+</Canvas>
+
+## With Contained Tags
+
+Another variant for displaying tags is achieved by turning on the `tagsContained` prop. By doing this, the look and feel
+of the component changes to a more contained one as tags are put inside the field itself.
+
+<Canvas>
+  <Story id="component-library-formik-elements-autocompletefield--with-contained-tags" />
+</Canvas>
+
+## With Complex Tags
+
+You can also pass complex objects as tags, there's no restriction to simple types. The _getCustomItem_ and _onAddCustomItem_ props
+take care of how your newly added props will be saved.
+See the description of these props in the [AutocompleteField Props section](#autocompletefield-props)
+of the documentation for best explanation of their usage.
+
+<Canvas>
+  <Story id="component-library-formik-elements-autocompletefield--with-complex-tags" />
+</Canvas>
+
+## With Adding Custom Tags
+
+If you want to enable adding custom tags, the _getCustomItem_ and _onAddCustomItem_ props
+take care of how your newly added props will be saved.
+See the description of these props in the [AutocompleteField Props section](#autocompletefield-props)
+of the documentation for best explanation of their usage.
+
+<Canvas>
+  <Story id="component-library-formik-elements-autocompletefield--with-adding-custom-tags" />
+</Canvas>
+
+## **(NEW) With Adding Custom Items**
+
+Using _getCustomItem_ prop you can enable the ability to check/select a newly added custom item.
+However, if you wish to persist the item inside the component even if it's unselected, you need to use the
+_onAddCustomItem_ prop alongside the _getCustomItem_ prop. Check the prop docs for more info.
+
+<Canvas>
+  <Story id="component-library-formik-elements-autocompletefield--with-adding-custom-items" />
+</Canvas>
+
 ## With Misused Props
 
 If you, for example, do the following:
-  - fetch an array from backend, but don't enable the `allowMultiple` prop or vice versa,
-  - pass an array instead of an async promise (decide to do full frontend fetch and filtering), but don't pass the `filter` prop <br />
-...the component automatically becomes disabled and notifies you to adjust the props accordingly.
+
+- fetch an array from backend, but don't enable the `allowMultiple` prop or vice versa,
+- pass an array instead of an async promise (decide to do full frontend fetch and filtering), but don't pass the `filter` prop <br />
+  ...the component automatically becomes disabled and notifies you to adjust the props accordingly.
 
 <Canvas>
   <Story id="component-library-formik-elements-autocompletefield--with-misused-props" />
@@ -306,7 +327,7 @@ If you, for example, do the following:
 ## Usage
 
 - Use `AutocompleteField` in a form as a way to allow the user to enter a value associated with a key, such as entering their name in a field labeled name
-and choosing from the list of available options.
+  and choosing from the list of available options.
 
 - You may wish to review the general forms documentation about designing forms.
 
@@ -317,26 +338,29 @@ and choosing from the list of available options.
 - All form inputs should have a related, unique label that either wraps it, or precedes it. The label for attribute should match its input’s id element, regardless of whether it wraps the element or not.
 
 - **Tip**: don't show too much info, some props like maxItems are optional for a reason, and the default value exists because
-it represents an optimal UX design.
+  it represents an optimal UX design.
 
 ## Best Practices
 
 - Use the sort prop to sort items, it is much easier for a user to find the item if the items are sorted
 - **Prefer Autocomplete Field over Select Field in most cases**, it gives the same features with the extra ability to search
 - If you want to truly have a Select Field experience on Autocomplete Field (all options listed), set the `maxItems` prop to
-the length of your items array
+  the length of your items array
 - If the size of your dataset is not large or you want a seamless experience, you may want to enable **filtering on frontend**
-for faster visual response without loading animations
+  for faster visual response without loading animations
 - Make sure to follow up with your validation (be it on frontend on backend) if you enable `required` prop, because the prop only
-visually defines the field as required
+  visually defines the field as required
 
 ## AutocompleteField Props:
 
 ### Field-specific props:
+
 <ArgsTable of={AutocompleteField} />
 
 ### Other props:
+
 <ArgsTable of={Autocomplete} />
 
 ## Autocomplete Tokens:
-<ThemeTokens component="Autocomplete"/>
+
+<ThemeTokens component="Autocomplete" />

--- a/storybook/src/formik-elements/AutocompleteField.stories.tsx
+++ b/storybook/src/formik-elements/AutocompleteField.stories.tsx
@@ -433,7 +433,7 @@ export const WithAddingCustomTags = () => {
   return (
     <AutocompleteField
       label={<Intl name="label" />}
-      placeholder="Type an arbitrary full name to add it to the list"
+      placeholder="Type an arbitrary tag name to add it to the list"
       {...frontendSimpleProps}
       options={finalItems}
       allowMultiple={true}

--- a/storybook/src/formik-elements/AutocompleteField.stories.tsx
+++ b/storybook/src/formik-elements/AutocompleteField.stories.tsx
@@ -27,6 +27,7 @@ import { defaultThemeConfig } from "@tiller-ds/theme";
 
 import storybookDictionary from "../intl/storybookDictionary";
 import {
+  beautifySource,
   FormikDecorator,
   getChangedTokensFromSource,
   Item,
@@ -69,11 +70,11 @@ export default {
   parameters: {
     docs: {
       page: mdx,
-      source: { type: "dynamic", excludeDecorators: true },
+      source: { type: "auto", excludeDecorators: true },
       transformSource: (source) => {
         const tokensConfig = { Select: "selectTokens", Autocomplete: "autocompleteTokens" };
         const correctedSource = source.replace(/function noRefCheck\(\)\s\{\}/g, "() => {}");
-        return getChangedTokensFromSource(correctedSource, tokensConfig);
+        return getChangedTokensFromSource(beautifySource(correctedSource), tokensConfig);
       },
     },
     design: {
@@ -125,7 +126,7 @@ export default {
       if: { arg: "tags" },
     },
     sendOptionValue: { name: "Send option value (on submit)", control: "boolean" },
-    onAddCustomTag: { name: "Enable adding custom tag", control: "boolean", if: { arg: "tags" } },
+    getCustomItem: { name: "Enable adding custom items", control: "boolean" },
     className: { name: "Class Name", control: "text" },
     useTokens: { name: "Use Tokens", control: "boolean" },
     autocompleteTokens: { name: "Autocomplete Tokens", control: "object" },
@@ -172,11 +173,11 @@ const backendProps = {
                 item.name
                   .concat(" " + item.surname)
                   .toLowerCase()
-                  .indexOf(query.toLowerCase()) !== -1
+                  .indexOf(query.toLowerCase()) !== -1,
             )
-          : items
+          : items,
       ),
-      500
+      500,
     ),
   getOptionValue: (item: Item) => item.username,
 };
@@ -192,11 +193,11 @@ const backendSimpleProps = {
                 item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
                 item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
                 item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-                item.toLowerCase().indexOf(query.toLowerCase()) !== -1
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1,
             )
-          : simpleItems
+          : simpleItems,
       ),
-      500
+      500,
     ),
 };
 
@@ -232,7 +233,7 @@ export const AutocompleteFieldFactory = ({
   tags,
   tagsContained,
   sendOptionValue,
-  onAddCustomTag,
+  getCustomItem,
   className,
   useTokens,
   autocompleteTokens,
@@ -275,7 +276,23 @@ export const AutocompleteFieldFactory = ({
     sendOptionValue={sendOptionValue}
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    onAddCustomTag={tags && onAddCustomTag ? (tagName) => "#" + tagName : undefined}
+    getCustomItem={
+      getCustomItem
+        ? (tagName) => {
+            if (tags) {
+              return "cust. " + tagName;
+            }
+            const name = tagName.split(" ")[0];
+            const surname = tagName.split(" ")[1];
+            const item: Item = {
+              name: name,
+              surname: surname ?? "",
+              username: surname ? tagName[0].toLowerCase() + surname.toLowerCase() : tagName[0].toLowerCase() ?? "",
+            };
+            return item;
+          }
+        : undefined
+    }
     className={className}
     autocompleteTokens={useTokens && autocompleteTokens}
     selectTokens={useTokens && selectTokens}
@@ -293,11 +310,11 @@ AutocompleteFieldFactory.args = {
   tooltipIcon: "info",
   iconVariant: "regular",
   allowMultiple: false,
+  getCustomItem: true,
   maxItems: 5,
   multipleSelectionLabel: false,
   tags: false,
   tagsContained: false,
-  onAddCustomTag: true,
   sendOptionValue: true,
   fetchFrontend: false,
   required: false,
@@ -383,41 +400,6 @@ export const WithMultipleSelectionAndVisibleLabels = () => (
   />
 );
 
-export const WithTags = () => (
-  <AutocompleteField
-    label={<Intl name="label" />}
-    {...frontendSimpleProps}
-    tags={true}
-    allowMultiple={true}
-    onAddCustomTag={(tag) => "#" + tag}
-  />
-);
-
-export const WithComplexTags = () => (
-  <AutocompleteField
-    label={<Intl name="label" />}
-    {...frontendProps}
-    tags={true}
-    allowMultiple={true}
-    onAddCustomTag={(tag) => ({
-      name: tag.split(" ")[0],
-      surname: tag.split(" ")[1] ?? "",
-      username: tag.split(" ")[1] ? tag[0].toLowerCase() + tag.split(" ")[1].toLowerCase() : tag[0].toLowerCase() ?? "",
-    })}
-  />
-);
-
-export const WithContainedTags = () => (
-  <AutocompleteField
-    label={<Intl name="label" />}
-    {...frontendSimpleProps}
-    tags={true}
-    tagsContained={true}
-    onAddCustomTag={(tag) => "#" + tag}
-    allowMultiple={true}
-  />
-);
-
 export const WithFilteringOnFrontend = () => (
   <AutocompleteField
     label={<Intl name="label" />}
@@ -426,6 +408,74 @@ export const WithFilteringOnFrontend = () => (
     allowMultiple={true}
   />
 );
+
+export const WithTags = () => (
+  <AutocompleteField label={<Intl name="label" />} {...frontendSimpleProps} allowMultiple={true} tags={true} />
+);
+
+export const WithComplexTags = () => (
+  <AutocompleteField label={<Intl name="label" />} {...frontendProps} allowMultiple={true} tags={true} />
+);
+
+export const WithContainedTags = () => (
+  <AutocompleteField
+    label={<Intl name="label" />}
+    {...frontendSimpleProps}
+    allowMultiple={true}
+    tags={true}
+    tagsContained={true}
+  />
+);
+
+export const WithAddingCustomTags = () => {
+  // incl-code
+  const [finalItems, setFinalItems] = React.useState<string[]>(simpleItems);
+  return (
+    <AutocompleteField
+      label={<Intl name="label" />}
+      placeholder="Type an arbitrary full name to add it to the list"
+      {...frontendSimpleProps}
+      options={finalItems}
+      allowMultiple={true}
+      tags={true}
+      getCustomItem={(tag) => "cust. " + tag}
+      onAddCustomItem={(item: string) => {
+        setFinalItems([...finalItems, item]);
+      }}
+    />
+  );
+};
+
+export const WithAddingCustomItems = () => {
+  // incl-code
+  const [finalItems, setFinalItems] = React.useState<Item[]>(items);
+  return (
+    <AutocompleteField
+      label={<Intl name="label" />}
+      placeholder="Type an arbitrary full name to add it to the list"
+      {...commonProps}
+      options={finalItems}
+      getOptionValue={(item: Item) => item.username}
+      filter={(name: string, option) =>
+        (option.name.toLowerCase() + " " + option.surname.toLowerCase()).includes(name.toLowerCase())
+      }
+      allowMultiple={true}
+      getCustomItem={(item) => {
+        const newItem = {
+          name: item.split(" ")[0],
+          surname: item.split(" ")[1] ?? "",
+          username: item.split(" ")[1]
+            ? item[0].toLowerCase() + item.split(" ")[1].toLowerCase()
+            : item[0].toLowerCase() ?? "",
+        };
+        return newItem;
+      }}
+      onAddCustomItem={(item) => {
+        setFinalItems([...finalItems, item]);
+      }}
+    />
+  );
+};
 
 export const WithMisusedProps = () => (
   <AutocompleteField {...backendProps} label={<Intl name="label" />} name={nameWithMultipleValues} />
@@ -449,7 +499,7 @@ const HideControls = {
   tags: { control: { disable: true } },
   tagsContained: { control: { disable: true } },
   sendOptionValue: { control: { disable: true } },
-  onAddCustomTag: { control: { disable: true } },
+  getCustomItem: { control: { disable: true } },
   className: { control: { disable: true } },
   useTokens: { control: { disable: true } },
   autocompleteTokens: { control: { disable: true } },

--- a/storybook/src/selectors/Autocomplete.mdx
+++ b/storybook/src/selectors/Autocomplete.mdx
@@ -3,7 +3,7 @@ import { Meta, ArgsTable, Story, Canvas } from "@storybook/addon-docs";
 import { Autocomplete } from "@tiller-ds/selectors";
 import { ThemeTokens } from "../utils";
 
-<Meta title="Docs|Autocomplete" component={ Autocomplete } />
+<Meta title="Docs|Autocomplete" component={Autocomplete} />
 
 # Autocomplete
 
@@ -26,10 +26,10 @@ using **controls**.
 To create your custom Autocomplete component:
 
 - Switch to the `Canvas` section of the Storybook and navigate to `Autocomplete Factory` story
-of the Autocomplete.
+  of the Autocomplete.
 - Modify props using controls.
 - When you're happy with what you've created, switch back to the `Docs` section, and you will be automatically
-navigated to your created Autocomplete.
+  navigated to your created Autocomplete.
 - After you click the `Show code` button below your custom Autocomplete, the code of the Autocomplete will be generated.
 
 ### Result:
@@ -53,7 +53,6 @@ export type Item = {
   surname: string;
 };
 ```
-
 
 ## Used Props
 
@@ -96,23 +95,23 @@ const complexProps = {
 const backendProps = {
   ...commonProps,
   options: (query: string) =>
-  promiseTimeout(
-    Promise.resolve(
-      query.length > 0
-      ? items.filter(
-      (item) =>
-      item.name.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.surname.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.username.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.name
-      .concat(" " + item.surname)
-      .toLowerCase()
-      .indexOf(query.toLowerCase()) !== -1
-      )
-      : items
+    promiseTimeout(
+      Promise.resolve(
+        query.length > 0
+          ? items.filter(
+              (item) =>
+                item.name.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.surname.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.username.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.name
+                  .concat(" " + item.surname)
+                  .toLowerCase()
+                  .indexOf(query.toLowerCase()) !== -1,
+            )
+          : items,
+      ),
+      500,
     ),
-    500
-  ),
   getOptionValue: (item: Item) => item.username,
 };
 ```
@@ -121,20 +120,20 @@ const backendProps = {
 const backendSimpleProps = {
   ...commonSimpleProps,
   options: (query: string) =>
-  promiseTimeout(
-    Promise.resolve(
-      query.length > 0
-      ? simpleItems.filter(
-      (item) =>
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-      item.toLowerCase().indexOf(query.toLowerCase()) !== -1
-      )
-      : simpleItems
+    promiseTimeout(
+      Promise.resolve(
+        query.length > 0
+          ? simpleItems.filter(
+              (item) =>
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1,
+            )
+          : simpleItems,
+      ),
+      500,
     ),
-    500
-  ),
 };
 ```
 
@@ -144,12 +143,12 @@ const frontendProps = {
   options: items,
   getOptionValue: (item: Item) => item.username,
   filter: (name: string, option) =>
-  (option.name.toLowerCase() + " " + option.surname.toLowerCase()).includes(name.toLowerCase()),
+    (option.name.toLowerCase() + " " + option.surname.toLowerCase()).includes(name.toLowerCase()),
 };
 ```
 
 ```ts
-  const frontendSimpleProps = {
+const frontendSimpleProps = {
   ...commonSimpleProps,
   options: simpleItems,
   filter: (name: string, option) => (option.toLowerCase() + " " + option.toLowerCase()).includes(name.toLowerCase()),
@@ -242,35 +241,6 @@ inside the field instead of a counter shown by default.
   <Story id="component-library-selectors-autocomplete--with-multiple-selection-and-visible-labels" />
 </Canvas>
 
-## **(NEW) With Tags**
-
-By enabling the `tags` prop, the look and feel of autocomplete changes in order to accompany the display of selected
-items as tags below the field. This gives you the ability to visualize selected items more explicitly and easily remove
-selected tags or add new tags. <br />
-It is recommended to use this variant with non-complex types (strings), but the usage with complex types is also possible.
-**Note**: `tags` prop requires `allowMultiple` prop to also be enabled in order to function.
-
-<Canvas>
-  <Story id="component-library-selectors-autocomplete--with-tags" />
-</Canvas>
-
-You can also use complex values for tags, but be careful because this is a bit more complicated to implement due to the nature of objects.
-Make sure you secure your `onAddCustomTag` function if you wish to have this option enabled when using complex types.
-The example below represents the secured usage of this function, no matter the input value.
-
-<Canvas>
-  <Story id="component-library-selectors-autocomplete--with-complex-tags" />
-</Canvas>
-
-## **(NEW) With Contained Tags**
-
-Another variant for displaying tags is achieved by turning on the `tagsContained` prop. By doing this, the look and feel
-of the component changes to a more contained one as tags are put inside the field itself.
-
-<Canvas>
-  <Story id="component-library-selectors-autocomplete--with-contained-tags" />
-</Canvas>
-
 ## With Filtering on Frontend
 
 If you enable filtering on the frontend you will experience **faster responses without loading animations** because
@@ -284,12 +254,74 @@ but it's important to define the filtering method on the frontend with the `filt
   <Story id="component-library-selectors-autocomplete--with-filtering-on-frontend" />
 </Canvas>
 
+## With Tags
+
+By enabling the `tags` prop, the look and feel of autocomplete field changes in order to accompany the display of selected
+items as tags below the field. This gives you the ability to visualize selected items more explicitly and easily remove
+selected tags or add new tags. <br />
+It is recommended to use this variant with non-complex types (strings), but the usage with complex types is also possible.
+**Note**: `tags` prop requires `allowMultiple` prop to also be enabled in order to function.
+
+<Canvas>
+  <Story id="component-library-selectors-autocomplete--with-tags" />
+</Canvas>
+
+You can also use complex values for tags, but be careful because this is a bit more complicated to implement due to the nature of objects.
+Make sure you secure your _getCustomItem_ and _onAddCustomItem_ functions if you wish to have this option enabled when using complex types.
+The example below represents the secured usage of this function, no matter the input value.
+
+<Canvas>
+  <Story id="component-library-selectors-autocomplete--with-complex-tags" />
+</Canvas>
+
+## With Contained Tags
+
+Another variant for displaying tags is achieved by turning on the `tagsContained` prop. By doing this, the look and feel
+of the component changes to a more contained one as tags are put inside the field itself.
+
+<Canvas>
+  <Story id="component-library-selectors-autocomplete--with-contained-tags" />
+</Canvas>
+
+## With Complex Tags
+
+You can also pass complex objects as tags, there's no restriction to simple types. The _getCustomItem_ and _onAddCustomItem_ props
+take care of how your newly added props will be saved.
+See the description of these props in the [Autocomplete Props section](#autocomplete-props)
+of the documentation for best explanation of their usage.
+
+<Canvas>
+  <Story id="component-library-selectors-autocomplete--with-complex-tags" />
+</Canvas>
+
+## With Adding Custom Tags
+
+If you want to enable adding custom tags, the _getCustomItem_ and _onAddCustomItem_ props
+take care of how your newly added props will be saved.
+See the description of these props in the [Autocomplete Props section](#autocomplete-props)
+of the documentation for best explanation of their usage.
+
+<Canvas>
+  <Story id="component-library-selectors-autocomplete--with-adding-custom-tags" />
+</Canvas>
+
+## **(NEW) With Adding Custom Items**
+
+Using _getCustomItem_ prop you can enable the ability to check/select a newly added custom item.
+However, if you wish to persist the item inside the component even if it's unselected, you need to use the
+_onAddCustomItem_ prop alongside the _getCustomItem_ prop. Check the prop docs for more info.
+
+<Canvas>
+  <Story id="component-library-selectors-autocomplete--with-adding-custom-items" />
+</Canvas>
+
 ## With Misused Props
 
 If you, for example, do the following:
-  - fetch an array from backend, but don't enable the `allowMultiple` prop or vice versa,
-  - pass an array instead of an async promise (decide to do full frontend fetch and filtering), but don't pass the `filter` prop <br />
-...the component automatically becomes disabled and notifies you to adjust the props accordingly.
+
+- fetch an array from backend, but don't enable the `allowMultiple` prop or vice versa,
+- pass an array instead of an async promise (decide to do full frontend fetch and filtering), but don't pass the `filter` prop <br />
+  ...the component automatically becomes disabled and notifies you to adjust the props accordingly.
 
 <Canvas>
   <Story id="component-library-selectors-autocomplete--with-misused-props" />
@@ -298,7 +330,7 @@ If you, for example, do the following:
 ## Usage
 
 - Use `Autocomplete` in a form as a way to allow the user to enter a value associated with a key, such as entering their name in a field labeled name
-and choosing from the list of available options.
+  and choosing from the list of available options.
 
 - You may wish to review the general forms documentation about designing forms.
 
@@ -309,21 +341,23 @@ and choosing from the list of available options.
 - All form inputs should have a related, unique label that either wraps it, or precedes it. The label for attribute should match its input’s id element, regardless of whether it wraps the element or not.
 
 - **Tip**: don't show too much info, some props like maxItems are optional for a reason, and the default value exists because
-it represents an optimal UX design.
+  it represents an optimal UX design.
 
 ## Best Practices
 
 - Use the sort prop to sort items, it is much easier for a user to find the item if the items are sorted
 - **Prefer Autocomplete over Select in most cases**, it gives the same features with the extra ability to search
 - If you want to truly have a Select Field experience on Autocomplete (all options listed), set the `maxItems` prop to
-the length of your items array
+  the length of your items array
 - If the size of your dataset is not large, or you want a seamless experience, you may want to enable **filtering on frontend**
-for faster visual response without loading animations
+  for faster visual response without loading animations
 - Make sure to follow up with your validation (be it on frontend on backend) if you enable `required` prop, because the prop only
-visually defines the field as required
+  visually defines the field as required
 
 ### Autocomplete Props:
+
 <ArgsTable of={Autocomplete} />
 
 ## Autocomplete Tokens:
-<ThemeTokens component="Autocomplete"/>
+
+<ThemeTokens component="Autocomplete" />

--- a/storybook/src/selectors/Autocomplete.stories.tsx
+++ b/storybook/src/selectors/Autocomplete.stories.tsx
@@ -411,7 +411,7 @@ export const WithAddingCustomTags = () => {
   return (
     <Autocomplete
       label={<Intl name="label" />}
-      placeholder="Type an arbitrary full name to add it to the list"
+      placeholder="Type an arbitrary tag name to add it to the list"
       {...frontendSimpleProps}
       options={finalItems}
       allowMultiple={true}

--- a/storybook/src/selectors/Autocomplete.stories.tsx
+++ b/storybook/src/selectors/Autocomplete.stories.tsx
@@ -26,7 +26,15 @@ import { Autocomplete } from "@tiller-ds/selectors";
 import { defaultThemeConfig } from "@tiller-ds/theme";
 
 import storybookDictionary from "../intl/storybookDictionary";
-import { getChangedTokensFromSource, Item, items, promiseTimeout, showFactoryDecorator, simpleItems } from "../utils";
+import {
+  beautifySource,
+  getChangedTokensFromSource,
+  Item,
+  items,
+  promiseTimeout,
+  showFactoryDecorator,
+  simpleItems,
+} from "../utils";
 
 import mdx from "./Autocomplete.mdx";
 
@@ -40,11 +48,11 @@ export default {
   parameters: {
     docs: {
       page: mdx,
-      source: { type: "dynamic", excludeDecorators: true },
+      source: { type: "auto", excludeDecorators: true },
       transformSource: (source) => {
         const tokensConfig = { Select: "selectTokens", Autocomplete: "autocompleteTokens" };
         const correctedSource = source.replace(/function noRefCheck\(\)\s\{\}/g, "() => {}");
-        return getChangedTokensFromSource(correctedSource, tokensConfig);
+        return getChangedTokensFromSource(beautifySource(correctedSource), tokensConfig);
       },
     },
     design: {
@@ -85,7 +93,7 @@ export default {
       if: { arg: "tags" },
     },
     sendOptionValue: { name: "Send option value (on submit)", control: "boolean" },
-    onAddCustomTag: { name: "Enable adding custom tag", control: "boolean", if: { arg: "tags" } },
+    getCustomItem: { name: "Enable adding custom items", control: "boolean" },
     className: { name: "Class Name", control: "text" },
     useTokens: { name: "Use Tokens", control: "boolean" },
     autocompleteTokens: { name: "Autocomplete Tokens", control: "object" },
@@ -146,11 +154,11 @@ const backendProps = {
                 item.name
                   .concat(" " + item.surname)
                   .toLowerCase()
-                  .indexOf(query.toLowerCase()) !== -1
+                  .indexOf(query.toLowerCase()) !== -1,
             )
-          : items
+          : items,
       ),
-      500
+      500,
     ),
   getOptionValue: (item: Item) => item.username,
 };
@@ -166,11 +174,11 @@ const backendSimpleProps = {
                 item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
                 item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
                 item.toLowerCase().indexOf(query.toLowerCase()) !== -1 ||
-                item.toLowerCase().indexOf(query.toLowerCase()) !== -1
+                item.toLowerCase().indexOf(query.toLowerCase()) !== -1,
             )
-          : simpleItems
+          : simpleItems,
       ),
-      500
+      500,
     ),
 };
 
@@ -206,7 +214,7 @@ export const AutocompleteFactory = ({
   tags,
   tagsContained,
   sendOptionValue,
-  onAddCustomTag,
+  getCustomItem,
   className,
   useTokens,
   autocompleteTokens,
@@ -249,7 +257,23 @@ export const AutocompleteFactory = ({
     sendOptionValue={sendOptionValue}
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    onAddCustomTag={tags && onAddCustomTag ? (tagName) => "#" + tagName : undefined}
+    getCustomItem={
+      getCustomItem
+        ? (tagName) => {
+            if (tags) {
+              return "cust. " + tagName;
+            }
+            const name = tagName.split(" ")[0];
+            const surname = tagName.split(" ")[1];
+            const item: Item = {
+              name: name,
+              surname: surname ?? "",
+              username: surname ? tagName[0].toLowerCase() + surname.toLowerCase() : tagName[0].toLowerCase() ?? "",
+            };
+            return item;
+          }
+        : undefined
+    }
     className={className}
     autocompleteTokens={useTokens && autocompleteTokens}
     selectTokens={useTokens && selectTokens}
@@ -271,7 +295,7 @@ AutocompleteFactory.args = {
   multipleSelectionLabel: false,
   tags: false,
   tagsContained: false,
-  onAddCustomTag: true,
+  getCustomItem: true,
   sendOptionValue: true,
   fetchFrontend: false,
   required: false,
@@ -359,45 +383,77 @@ export const WithMultipleSelectionAndVisibleLabels = () => (
   />
 );
 
+export const WithFilteringOnFrontend = () => (
+  <Autocomplete label={<Intl name="label" />} {...frontendProps} name={name} allowMultiple={true} />
+);
+
 export const WithTags = () => (
-  <Autocomplete
-    label={<Intl name="label" />}
-    {...frontendSimpleProps}
-    tags={true}
-    allowMultiple={true}
-    onAddCustomTag={(tag) => "#" + tag}
-  />
+  <Autocomplete label={<Intl name="label" />} {...frontendSimpleProps} allowMultiple={true} tags={true} />
 );
 
 export const WithComplexTags = () => (
-  <Autocomplete
-    label={<Intl name="label" />}
-    {...frontendProps}
-    tags={true}
-    allowMultiple={true}
-    onAddCustomTag={(tag) => ({
-      name: tag.split(" ")[0],
-      surname: tag.split(" ")[1] ?? "",
-      username: tag.split(" ")[1] ? tag[0].toLowerCase() + tag.split(" ")[1].toLowerCase() : tag[0].toLowerCase() ?? "",
-    })}
-  />
+  <Autocomplete label={<Intl name="label" />} {...frontendProps} allowMultiple={true} tags={true} />
 );
 
 export const WithContainedTags = () => (
   <Autocomplete
     label={<Intl name="label" />}
     {...frontendSimpleProps}
+    allowMultiple={true}
     tags={true}
     tagsContained={true}
-    onAddCustomTag={(tag) => "#" + tag}
-    allowMultiple={true}
   />
 );
 
-export const WithFilteringOnFrontend = () => (
-  <Autocomplete label={<Intl name="label" />} {...frontendProps} name={name} allowMultiple={true} />
-);
+export const WithAddingCustomTags = () => {
+  // incl-code
+  const [finalItems, setFinalItems] = React.useState<string[]>(simpleItems);
+  return (
+    <Autocomplete
+      label={<Intl name="label" />}
+      placeholder="Type an arbitrary full name to add it to the list"
+      {...frontendSimpleProps}
+      options={finalItems}
+      allowMultiple={true}
+      tags={true}
+      getCustomItem={(tag) => "cust. " + tag}
+      onAddCustomItem={(item: string) => {
+        setFinalItems([...finalItems, item]);
+      }}
+    />
+  );
+};
 
+export const WithAddingCustomItems = () => {
+  // incl-code
+  const [finalItems, setFinalItems] = React.useState<Item[]>(items);
+  return (
+    <Autocomplete
+      label={<Intl name="label" />}
+      placeholder="Type an arbitrary full name to add it to the list"
+      {...commonProps}
+      options={finalItems}
+      getOptionValue={(item: Item) => item.username}
+      filter={(name: string, option) =>
+        (option.name.toLowerCase() + " " + option.surname.toLowerCase()).includes(name.toLowerCase())
+      }
+      allowMultiple={true}
+      getCustomItem={(item) => {
+        const newItem = {
+          name: item.split(" ")[0],
+          surname: item.split(" ")[1] ?? "",
+          username: item.split(" ")[1]
+            ? item[0].toLowerCase() + item.split(" ")[1].toLowerCase()
+            : item[0].toLowerCase() ?? "",
+        };
+        return newItem;
+      }}
+      onAddCustomItem={(item) => {
+        setFinalItems([...finalItems, item]);
+      }}
+    />
+  );
+};
 export const WithMisusedProps = () => <Autocomplete {...backendProps} label={<Intl name="label" />} name={name} />;
 
 const HideControls = {
@@ -418,7 +474,7 @@ const HideControls = {
   tags: { control: { disable: true } },
   tagsContained: { control: { disable: true } },
   sendOptionValue: { control: { disable: true } },
-  onAddCustomTag: { control: { disable: true } },
+  getCustomItem: { control: { disable: true } },
   className: { control: { disable: true } },
   useTokens: { control: { disable: true } },
   autocompleteTokens: { control: { disable: true } },


### PR DESCRIPTION
## Basic information

* Tiller version: 1.3.0
* Module: selectors

## Description

- renamed prop onAddCustomTag to getCustomItem
- added onAddCustomItem prop for handling new items persistence inside the component
- adding new custom items is now available for all Autocomplete variants

### Related issue

Closes #69

## Types of changes

- Enhancement (semi-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)
- Docs improvement

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass

