### PR TITLE
#81 Add description to modules

### DIFF
--- a/libs/alert/package.json
+++ b/libs/alert/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/alert",
   "version": "0.0.0-dev",
+  "description": "Alert module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/core",
   "version": "0.0.0-dev",
+  "description": "Core module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/data-display/package.json
+++ b/libs/data-display/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/data-display",
   "version": "0.0.0-dev",
+  "description": "Data display module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/date/package.json
+++ b/libs/date/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/date",
   "version": "0.0.0-dev",
+  "description": "Date module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/dev/package.json
+++ b/libs/dev/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/dev",
   "version": "0.0.0-dev",
+  "description": "Dev module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/form-elements-advanced/package.json
+++ b/libs/form-elements-advanced/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/form-elements-advanced",
   "version": "0.0.0-dev",
+  "description": "Form elements module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/form-elements/package.json
+++ b/libs/form-elements/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/form-elements",
   "version": "0.0.0-dev",
+  "description": "Form elements module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/formik-elements/package.json
+++ b/libs/formik-elements/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/formik-elements",
   "version": "0.0.0-dev",
+  "description": "Formik elements module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/icons/package.json
+++ b/libs/icons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/icons",
   "version": "0.0.0-dev",
+  "description": "Icons module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/intl/package.json
+++ b/libs/intl/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/intl",
   "version": "0.0.0-dev",
+  "description": "Intl module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/menu/package.json
+++ b/libs/menu/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/menu",
   "version": "0.0.0-dev",
+  "description": "Menu module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/patterns/package.json
+++ b/libs/patterns/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/patterns",
   "version": "0.0.0-dev",
+  "description": "Patterns module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/selectors/package.json
+++ b/libs/selectors/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/selectors",
   "version": "0.0.0-dev",
+  "description": "Selectors module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/theme/package.json
+++ b/libs/theme/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/theme",
   "version": "0.0.0-dev",
+  "description": "Theme module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/upload/package.json
+++ b/libs/upload/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/upload",
   "version": "0.0.0-dev",
+  "description": "Upload module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",

--- a/libs/util/package.json
+++ b/libs/util/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tiller-ds/util",
   "version": "0.0.0-dev",
+  "description": "Util module of Tiller Design System",
   "keywords": [
     "accessibility",
     "component library",


### PR DESCRIPTION
## Basic information

* Tiller version: 1.3.0
* Module: project

## Description

Add description property to `package.json` for every module.

### Related issue

Closes #81

## Types of changes

- Visibility improvement

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass

