### PR TITLE
#87 Fix Autocomplete and Select mobile issues on CRA

### DIFF
--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -599,7 +599,7 @@ function Autocomplete<T extends {}>({
   };
 
   const checkItem = (index: number, customTag?: boolean) => {
-    const selectedOption = highlightedOption || filteredOptions[index];
+    const selectedOption = filteredOptions[index] || highlightedOption;
     if (allowMultiple && (highlightedOption || index > -1)) {
       if (getOptionValue) {
         if (arrayIncludes(selectedOptions, selectedOption)) {

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -189,7 +189,7 @@ function Select<T>({
   //used only for form submit on enter
   const inputRef = React.useRef<HTMLInputElement>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const stateChangeRef = React.useRef<any>(null);
+  const itemClickRef = React.useRef<any>(null);
 
   const selectionTypes: unknown[] = [
     useSelect.stateChangeTypes.MenuKeyDownEnter,
@@ -204,18 +204,23 @@ function Select<T>({
   }, [options, sort]);
 
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
-  const { getToggleButtonProps, getItemProps, getMenuProps, isOpen, closeMenu, openMenu, highlightedIndex, reset } =
-    useSelect<T>({
-      items: filteredOptions,
-      labelId: id,
-      selectedItem: null,
-      isOpen: isMenuOpen,
-      onStateChange: (state) => {
-        const { type, selectedItem } = state as { type: UseSelectStateChangeTypes; selectedItem?: T };
+  const { getToggleButtonProps, getItemProps, getMenuProps, isOpen, highlightedIndex, reset } = useSelect<T>({
+    items: filteredOptions,
+    labelId: id,
+    selectedItem: null,
+    isOpen: isMenuOpen,
+    onStateChange: (state) => {
+      const { type, selectedItem } = state as { type: UseSelectStateChangeTypes; selectedItem?: T };
 
-        if (type === useSelect.stateChangeTypes.ItemClick) {
-          setIsMenuOpen(allowMultiple);
-        }
+      if (selectedItem === itemClickRef.current) {
+        itemClickRef.current = null;
+        return;
+      }
+
+      if (type === useSelect.stateChangeTypes.ItemClick) {
+        itemClickRef.current = selectedItem;
+        setIsMenuOpen(allowMultiple);
+      }
 
         if (selectionTypes.indexOf(type) !== -1 || type === useSelect.stateChangeTypes.FunctionReset) {
           if (allowMultiple) {


### PR DESCRIPTION
## Basic information

* Tiller version: 1.3.1
* Module: @tiller-ds/selectors

## Bug description

Select and Autocomplete have issues on CRA and other related frameworks which use `react-scripts` dependency when
using them on a mobile device. Select enters a loop when clicking on an item, while Autocomplete's precision is not correct when selecting an item from a menu when an input value is present.

### Related issue

Closes #87 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
