### PR TITLE
#94 Fix dislocated mask on Date/Time Inputs

### DIFF
--- a/libs/date/src/DateInput.tsx
+++ b/libs/date/src/DateInput.tsx
@@ -193,6 +193,7 @@ export default function DateInput({
 
   const onDatesChange = (data: OnDatesChangeProps) => {
     props.onChange(data.startDate);
+    setTypedValue(dateFns.format(data.startDate as Date, finalDateFormat));
     setOpened(false);
   };
 

--- a/libs/date/src/DateRangeInput.tsx
+++ b/libs/date/src/DateRangeInput.tsx
@@ -273,7 +273,7 @@ export default function DateRangeInput({
       setDatePickerState({
         startDate: start,
         endDate: end,
-        focusedInput: null,
+        focusedInput: START_DATE,
       });
     } else if (start && !end) {
       setDatePickerState({ startDate: start ?? null, endDate: null, focusedInput: END_DATE });

--- a/libs/date/src/DateTimeInput.tsx
+++ b/libs/date/src/DateTimeInput.tsx
@@ -228,7 +228,9 @@ export default function DateTimeInput({
     const selectedDate = data.startDate ? data.startDate : new Date();
 
     if (selectedDate !== value && selectedDate !== minDate) {
-      props.onChange(createNewDate(selectedDate, currentHours, currentMinutes));
+      const newDate = createNewDate(selectedDate, currentHours, currentMinutes);
+      props.onChange(newDate);
+      setTypedValue(formatValue(newDate));
       setShowTimePickerMinutes(false);
       openSelectedPicker("time");
     }
@@ -287,13 +289,16 @@ export default function DateTimeInput({
   const formattedDateFormat = dateFormat?.replace(/m/g, "M");
   const finalDateFormat = formattedDateFormat || getDateFormatByLang(lang);
   const timeAddOn = " HH:mm"; // HH must be uppercase!
-  const formattedValue = value
-    ? `${dateFns.format(value, finalDateFormat)} ${addLeadingZerosToDigit(
-        isTwelveHours ? timePicker.hour : value.getHours(),
-      )}:${addLeadingZerosToDigit(isTwelveHours ? timePicker.minute : value.getMinutes())}${
-        isTwelveHours ? " " + timePicker.type : ""
-      }`
-    : "";
+
+  const formatValue = (value: Date) => {
+    return `${dateFns.format(value, finalDateFormat)} ${addLeadingZerosToDigit(
+      isTwelveHours ? timePicker.hour : value.getHours(),
+    )}:${addLeadingZerosToDigit(isTwelveHours ? timePicker.minute : value.getMinutes())}${
+      isTwelveHours ? " " + timePicker.type : ""
+    }`;
+  };
+
+  const formattedValue = value ? formatValue(value) : "";
   const [typedValue, setTypedValue] = React.useState<string>(formattedValue);
 
   const mobile = (window.innerWidth < 768) as boolean;


### PR DESCRIPTION
## Basic information

* Tiller version: 1.4.0
* Module: date

## Bug description

When selecting a date from the picker on Date Input and Date Time Input components the date mask dislocates when
focusing on an input. Manual entry doesn't cause this effect and works normally. 

### Related issue

Closes #94 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
