### PR TITLE
#97 Add valueTransform prop to InputField

### DIFF
--- a/storybook/src/formik-elements/InputField.stories.tsx
+++ b/storybook/src/formik-elements/InputField.stories.tsx
@@ -81,6 +81,11 @@ export default {
     label: { name: "Label", control: "text" },
     help: { name: "Help", control: "text" },
     placeholder: { name: "Placeholder", control: "text" },
+    valueTransform: {
+      name: "Transform Value",
+      options: ["uppercase", "lowercase", "capitalize"],
+      control: { type: "radio" },
+    },
     tooltipText: { name: "Tooltip Text (on hover)", control: "text" },
     tooltipToggle: { name: "Toggle Tooltip (on/off)", control: { type: "boolean" } },
     tooltipIcon: { name: "Tooltip Icon", control: { type: "select", options: iconTypes } },
@@ -117,6 +122,7 @@ export const InputFieldFactory = ({
   className,
   useTokens,
   tokens,
+  valueTransform,
 }) => (
   <InputField
     name={name}
@@ -137,6 +143,7 @@ export const InputFieldFactory = ({
     allowClear={allowClear}
     className={className}
     tokens={useTokens && tokens}
+    valueTransform={valueTransform}
   />
 );
 
@@ -145,6 +152,7 @@ InputFieldFactory.args = {
   label: "Test Label",
   help: "",
   placeholder: "Test placeholder",
+  valueTransform: "lowercase",
   tooltipToggle: false,
   tooltipText: "Test tooltip content",
   tooltipIcon: "info",
@@ -174,6 +182,10 @@ export const WithLabel = () => (
 export const WithoutLabel = () => <InputField name={name} />;
 
 export const WithValue = () => <InputField name={nameWithValue} label={<Intl name="label" />} />;
+
+export const WithTransformedValue = () => (
+  <InputField name={nameWithValue} label={<Intl name="label" />} valueTransform="uppercase" />
+);
 
 export const Disabled = () => <InputField name={nameWithValue} label={<Intl name="label" />} disabled={true} />;
 
@@ -270,6 +282,7 @@ const HideControls = {
 WithLabel.argTypes = HideControls;
 WithoutLabel.argTypes = HideControls;
 WithValue.argTypes = HideControls;
+WithTransformedValue.argTypes = HideControls;
 Disabled.argTypes = HideControls;
 WithPlaceholder.argTypes = HideControls;
 WithHelp.argTypes = HideControls;


### PR DESCRIPTION
## Basic information

* Tiller version: 1.4.0
* Module: formik-elements

## Additional information

Add custom text transform prop. 

## Description

Add valueTransform prop which is function or a string that determines how the input value should be transformed when the user types into the input field. In case it's a function, it will be called every time the input value changes. The function can then modify the value as needed and return the modified value.

### Related issue

Closes #97 

## Types of changes
- Enhancement (non-breaking change which enhances existing functionality)

## Checklist
- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
