### PR TITLE
#91 Add possibility of highlighting current date to date inputs

### DIFF
--- a/libs/date/src/DateInput.tsx
+++ b/libs/date/src/DateInput.tsx
@@ -76,8 +76,10 @@ export type DateInputProps = {
   error?: React.ReactNode;
 
   /**
-   * On by default. If true, the popover for choosing a date is set to always have the same optimal width (370px),
+   * If true, the popover for choosing a date is set to always have the same optimal width (370px),
    * meaning it won't stretch with the field component. Only applies to desktop displays.
+   *
+   * On by default.
    */
   fixedPopoverWidth?: boolean;
 
@@ -85,6 +87,13 @@ export type DateInputProps = {
    * The help text displayed below the date input field.
    */
   help?: React.ReactNode;
+
+  /**
+   * If true, the current date is highlighted in the date picker for easier navigation.
+   *
+   * Off by default.
+   */
+  highlightToday?: boolean;
 
   /**
    * Represents the label above the date input field.
@@ -181,6 +190,7 @@ export default function DateInput({
   popoverPosition = "left",
   closeAfterEntry,
   dateFormat,
+  highlightToday,
   ...props
 }: DateInputProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -281,6 +291,7 @@ export default function DateInput({
             maxYear={maxDate?.getFullYear()}
             isDateRange={false}
             fixedWidth={fixedPopoverWidth}
+            highlightToday={highlightToday}
           />
         )}
       </Popover>

--- a/libs/date/src/DatePicker.tsx
+++ b/libs/date/src/DatePicker.tsx
@@ -31,6 +31,7 @@ type DatePickerProps = {
   isDateRange: boolean;
   maxYear?: number;
   minYear?: number;
+  highlightToday?: boolean;
 };
 
 type MonthPickerProps = {
@@ -93,6 +94,7 @@ type DatePickerContext = {
   onActiveMonthToggle: (value: ActiveMonth) => void;
   isDateRange: boolean;
   startDate: Date | null;
+  highlightToday?: boolean;
 };
 
 type DatePickerContextProps = {
@@ -103,6 +105,7 @@ type DatePickerContextProps = {
   startDate: Date | null;
   isDateRange: boolean;
   children: React.ReactNode;
+  highlightToday?: boolean;
 };
 
 const DatePickerContext = React.createContext<DatePickerContext | null>(null);
@@ -136,6 +139,7 @@ function DatePickerContextProvider({
   startDate,
   isDateRange,
   children,
+  highlightToday,
 }: DatePickerContextProps) {
   const [dayPicker, setDayPicker] = React.useState<boolean>(true);
   const [activeMonth, setActiveMonth] = React.useState<ActiveMonth>({ month: 0, year: 0 });
@@ -161,6 +165,7 @@ function DatePickerContextProvider({
         activeMonth,
         onActiveMonthToggle,
         isDateRange,
+        highlightToday,
       }}
     >
       {children}
@@ -177,6 +182,7 @@ export default function DatePicker({
   maxYear,
   isDateRange,
   className,
+  highlightToday,
 }: DatePickerProps) {
   return (
     <DatePickerContextProvider
@@ -186,6 +192,7 @@ export default function DatePicker({
       minYear={minYear}
       maxYear={maxYear}
       isDateRange={isDateRange}
+      highlightToday={highlightToday}
     >
       {!isDateRange && <DatePickerContainer className={className} fixedWidth={fixedWidth} />}
       {isDateRange && <DateRangePickerContainer className={className} fixedWidth={fixedWidth} />}
@@ -492,7 +499,7 @@ export function DaysPicker({ weekdayLabels, days, ...props }: DaysPickerProps) {
 
 function DatePickerDay({ dayLabel, date, ...props }: DatePickerDayProps) {
   const tokens = useTokens("DateInput", props.tokens);
-  const { startDate, datePicker, isDateRange } = useDatePickerContext();
+  const { startDate, datePicker, isDateRange, highlightToday } = useDatePickerContext();
 
   const { onClick, onKeyDown, onMouseEnter, tabIndex, disabledDate } = useDay({
     date,
@@ -510,7 +517,11 @@ function DatePickerDay({ dayLabel, date, ...props }: DatePickerDayProps) {
     { [tokens.DatePicker.Button.firstOrLast]: datePicker.isFirstOrLastSelectedDate(date) },
     { [tokens.DatePicker.Button.hovered]: datePicker.isDateHovered(date) && isDateRange },
     {
-      [tokens.DatePicker.Button.dateHovered]: !disabledDate && startDate?.getTime() !== date.getTime() && !isDateRange,
+      [tokens.DatePicker.Button.currentDate]: new Date().toDateString() === date.toDateString() && highlightToday,
+    },
+    {
+      [tokens.DatePicker.Button.dateHovered]:
+        !disabledDate && startDate?.getTime() !== date.getTime() && !datePicker.isDateSelected(date),
     },
     { [tokens.DatePicker.Button.disabled]: disabledDate },
   );

--- a/libs/date/src/DateRangeInput.tsx
+++ b/libs/date/src/DateRangeInput.tsx
@@ -83,8 +83,10 @@ export type DateRangeInputProps = {
   error?: React.ReactNode;
 
   /**
-   * On by default. If true, the popover for choosing a date is set to always have the same optimal width (500px),
+   * If true, the popover for choosing a date is set to always have the same optimal width (500px),
    * meaning it won't stretch with the field component. Only applies to desktop displays.
+   *
+   * On by default.
    */
   fixedPopoverWidth?: boolean;
 
@@ -92,6 +94,13 @@ export type DateRangeInputProps = {
    * The help text displayed below the date input field.
    */
   help?: React.ReactNode;
+
+  /**
+   * If true, the current date is highlighted in the date picker for easier navigation.
+   *
+   * Off by default.
+   */
+  highlightToday?: boolean;
 
   /**
    * Represents the label above the date input field.
@@ -197,6 +206,7 @@ export default function DateRangeInput({
   closeAfterEntry,
   onBlur,
   dateFormat,
+  highlightToday,
   ...props
 }: DateRangeInputProps) {
   const { lang } = useIntlContext();
@@ -396,6 +406,7 @@ export default function DateRangeInput({
             maxYear={maxDate?.getFullYear()}
             isDateRange={true}
             fixedWidth={fixedPopoverWidth}
+            highlightToday={highlightToday}
           />
         )}
       </Popover>

--- a/libs/date/src/DateTimeInput.tsx
+++ b/libs/date/src/DateTimeInput.tsx
@@ -83,8 +83,10 @@ export type DateTimeInputProps = {
   error?: React.ReactNode;
 
   /**
-   * On by default. If true, the popover for choosing a date is set to always have the same optimal width (370px),
+   * If true, the popover for choosing a date is set to always have the same optimal width (370px),
    * meaning it won't stretch with the field component. Only applies to desktop displays.
+   *
+   * On by default.
    */
   fixedPopoverWidth?: boolean;
 
@@ -92,6 +94,13 @@ export type DateTimeInputProps = {
    * The help text displayed below the date time input field.
    */
   help?: React.ReactNode;
+
+  /**
+   * If true, the current date is highlighted in the date picker for easier navigation.
+   *
+   * Off by default.
+   */
+  highlightToday?: boolean;
 
   /**
    * Represents the label above the date time input field.
@@ -167,6 +176,7 @@ export default function DateTimeInput({
   dynamicMask = true,
   showMaskOnEmpty,
   dateFormat,
+  highlightToday,
   ...props
 }: DateTimeInputProps & DateTimeInputTokens) {
   const { lang } = useIntlContext();
@@ -445,6 +455,7 @@ export default function DateTimeInput({
                   maxYear={maxDate?.getFullYear()}
                   className={dateTimeInputTokens.borderRadius}
                   fixedWidth={fixedPopoverWidth}
+                  highlightToday={highlightToday}
                 />
               )}
               {!isDatePicker && (

--- a/libs/date/src/TimeInput.tsx
+++ b/libs/date/src/TimeInput.tsx
@@ -71,8 +71,10 @@ export type TimeInputProps = {
   error?: React.ReactNode;
 
   /**
-   * On by default. If true, the popover for choosing a time is set to always have the same optimal width (370px),
+   * If true, the popover for choosing a time is set to always have the same optimal width (370px),
    * meaning it won't stretch with the field component. Only applies to desktop displays.
+   *
+   * On by default.
    */
   fixedPopoverWidth?: boolean;
 

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -739,6 +739,7 @@ const defaultComponentConfig = {
         firstOrLast: "bg-primary text-primary-contrast",
         selected: "bg-primary-light text-primary-contrast",
         hovered: "bg-primary-light text-primary-contrast",
+        currentDate: "ring-2 ring-inset ring-white border border-primary-dark text-primary-dark",
         dateHovered: `hover:bg-primary hover:text-primary-contrast`,
         yearHovered: `hover:bg-primary hover:text-primary-contrast`,
         disabled: "opacity-50 text-slate-700 ",

--- a/storybook/src/date/DateInput.stories.tsx
+++ b/storybook/src/date/DateInput.stories.tsx
@@ -194,3 +194,15 @@ export const WithMinAndMaxDateAndValue = () => (
     onBlur={() => {}}
   />
 );
+
+export const WithHighlightedCurrentDate = () => (
+  <DateInput
+    name={name}
+    value={null}
+    label={<Intl name="label" />}
+    onChange={() => {}}
+    onReset={() => {}}
+    onBlur={() => {}}
+    highlightToday={true}
+  />
+);

--- a/storybook/src/date/DateRangeInput.stories.tsx
+++ b/storybook/src/date/DateRangeInput.stories.tsx
@@ -73,6 +73,8 @@ export const WithState = () => {
   );
 };
 
+export const WithLabel = () => <DateRangeInput label={<Intl name="label" />} name={name} onChange={() => {}} />;
+
 export const WithoutLabel = () => <DateRangeInput name={name} onChange={() => {}} />;
 
 export const WithValue = () => (
@@ -122,4 +124,8 @@ export const WithError = () => <DateRangeInput name={name} onChange={() => {}} e
 
 export const WithMinAndMaxDate = () => (
   <DateRangeInput name={name} minDate={new Date("2020-10-05")} maxDate={new Date("2020-11-20")} onChange={() => {}} />
+);
+
+export const WithHighlightedCurrentDate = () => (
+  <DateRangeInput label={<Intl name="label" />} name={name} onChange={() => {}} highlightToday={true} />
 );

--- a/storybook/src/date/DateTimeInput.stories.tsx
+++ b/storybook/src/date/DateTimeInput.stories.tsx
@@ -219,3 +219,15 @@ export const WithTwelveHoursAndValue = () => (
     type="use12Hours"
   />
 );
+
+export const WithHighlightedCurrentDate = () => (
+  <DateTimeInput
+    name={name}
+    label={<Intl name="label" />}
+    value={null}
+    onChange={() => {}}
+    onReset={() => {}}
+    onBlur={() => {}}
+    highlightToday={true}
+  />
+);

--- a/storybook/src/formik-elements/DateInputField.stories.tsx
+++ b/storybook/src/formik-elements/DateInputField.stories.tsx
@@ -149,3 +149,7 @@ export const WithMinAndMaxDateAndValue = () => {
     />
   );
 };
+
+export const WithHighlightedCurrentDate = () => (
+  <DateInputField name={name} label={<Intl name="label" />} highlightToday={true} />
+);

--- a/storybook/src/formik-elements/DateRangeInputField.stories.tsx
+++ b/storybook/src/formik-elements/DateRangeInputField.stories.tsx
@@ -157,3 +157,7 @@ export const WithEndError = () => <DateRangeInputField start={start} end={endWit
 export const WithMinAndMaxDate = () => (
   <DateRangeInputField start={start} end={end} minDate={new Date("2020-10-05")} maxDate={new Date("2025-01-01")} />
 );
+
+export const WithHighlightedCurrentDate = () => (
+  <DateRangeInputField start={start} end={end} label={<Intl name="label" />} highlightToday={true} />
+);

--- a/storybook/src/formik-elements/DateTimeInputField.stories.tsx
+++ b/storybook/src/formik-elements/DateTimeInputField.stories.tsx
@@ -145,3 +145,7 @@ export const WithTwelveHoursAndValue = () => {
   };
   return <DateTimeInputField name={nameWithValue} label={<Intl name="label" />} type="use12Hours" />;
 };
+
+export const WithHighlightedCurrentDate = () => (
+  <DateTimeInputField name={name} label={<Intl name="label" />} highlightToday={true} />
+);


### PR DESCRIPTION
## Basic information

* Tiller version: 1.5.0
* Module: date

## Description

- added _highlightToday_ prop to: `DateInput`, `DateRangeInput`, `DateTimeInput`
- added `WithHighlightedCurrentDate` stories to inputs to showcase the behaviour
- added new `currentDate` token which includes styling for today's date  (`DatePicker.Button.currentDate`)

### Related issue

Closes #91 

## Types of changes

- Visual improvements (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass

