### PR TITLE
#106 Fix AppPicker not visible inside Storybook

### DIFF
--- a/storybook/src/menu/AppPicker.stories.tsx
+++ b/storybook/src/menu/AppPicker.stories.tsx
@@ -22,12 +22,9 @@ import { withDesign } from "storybook-addon-designs";
 
 import { AppPicker } from "@tiller-ds/menu";
 
-import mdx from "./AppPicker.mdx";
+import { beautifySource } from "../utils";
 
-const applications = [
-  { name: "Employee Boarding", path: "/employee-boarding" },
-  { name: "Invoice Request", path: "/invoice-request" },
-];
+import mdx from "./AppPicker.mdx";
 
 const logo = (
   <div className="h-8 w-8 rounded-full">
@@ -50,6 +47,8 @@ export default {
   parameters: {
     docs: {
       page: mdx,
+      source: { type: "auto", excludeDecorators: true },
+      transformSource: (source: string) => beautifySource(source),
     },
     design: {
       type: "figma",
@@ -59,8 +58,20 @@ export default {
   },
 };
 
-export const Example = () => (
-  <BrowserRouter basename="/test">
-    <AppPicker applications={applications}>{logo}</AppPicker>
-  </BrowserRouter>
-);
+export const Example = () => {
+  // incl-code
+  const applications = [
+    { name: "App 1", path: "/app1" },
+    { name: "App 2", path: "/app2" },
+    { name: "App 3", path: "/app3" },
+  ];
+
+  const currentApplication = applications[0].path;
+  return (
+    <BrowserRouter basename="/">
+      <AppPicker applications={applications} currentApplication={currentApplication}>
+        {logo}
+      </AppPicker>
+    </BrowserRouter>
+  );
+};


### PR DESCRIPTION
## Basic information

* Tiller version: 1.5.0
* Module: storybook

## Bug description

When accessing the AppPicker component in Storybook, the component is invisible inside Storybook. 
The docs and code are displayed properly, but the visual representation is missing.

### Related issue

Closes #106

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
