### PR TITLE
#110 Improve AutocompleteField value change consistency when sendOptionValue is disabled

### DIFF
--- a/libs/formik-elements/src/AutocompleteField.tsx
+++ b/libs/formik-elements/src/AutocompleteField.tsx
@@ -86,11 +86,12 @@ export default function AutocompleteField<T>({
     } else {
       helpers.setValue(value, shouldValidate);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const lastFieldValue = React.useRef<unknown>(null);
   React.useEffect(() => {
-    if (getOptionValue && field.value && !isEqual(lastFieldValue.current, field.value)) {
+    if (getOptionValue && field.value && !isEqual(lastFieldValue.current, field.value) && sendOptionValue) {
       if (Array.isArray(field.value)) {
         helpers.setValue(field.value.map(getOptionValue), shouldValidate);
         lastFieldValue.current = field.value.map(getOptionValue);
@@ -101,9 +102,13 @@ export default function AutocompleteField<T>({
       }
       setValue(field.value);
       initialError.current = undefined;
-    } else if (!field.value || (Array.isArray(field.value) && field.value.length === 0)) {
+    } else if ((!field.value || (Array.isArray(field.value) && field.value.length === 0)) && sendOptionValue) {
       lastFieldValue.current = undefined;
       setValue(undefined);
+    } else if (!sendOptionValue) {
+      helpers.setValue(field.value, shouldValidate);
+      lastFieldValue.current = field.value;
+      setValue(field.value);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [field.value]);


### PR DESCRIPTION
## Basic information

* Tiller version: 1.6.0
* Module: selectors

## Bug description

Setting a new value through Formik helpers for `AutocompleteField` doesn't work as expected when _sendOptionValue_ is set to `false`. In this case, the value correctly changes in the end, but gets set incorrectly before that by setting the value as if the _sendOptionValue_ prop is disabled. This behaviour should be consistent in its results when changing the value in order to correctly track the field values.

### Related issue

Closes #110

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
