### PR TITLE
#113 Fix inconsistent onBlur for Date, DateTime and Time inputs

### DIFF
--- a/libs/date/src/DateInput.tsx
+++ b/libs/date/src/DateInput.tsx
@@ -217,7 +217,7 @@ export default function DateInput({
     numberOfMonths: 1,
     onDatesChange,
   });
-  const { opened, setOpened } = usePickerOpener(false, inputRef, datePickerRef, (onBlur = undefined));
+  const { opened, setOpened } = usePickerOpener(false, inputRef, datePickerRef, undefined);
 
   const checkActiveMonthsValidity =
     value &&

--- a/libs/date/src/DateTimeInput.tsx
+++ b/libs/date/src/DateTimeInput.tsx
@@ -194,7 +194,7 @@ export default function DateTimeInput({
   const [isDatePicker, setIsDatePicker] = React.useState<boolean>(true);
   const [showTimePickerMinutes, setShowTimePickerMinutes] = React.useState(false);
 
-  const { opened, setOpened } = usePickerOpener(false, inputRef, dateTimePickerRef, onBlur);
+  const { opened, setOpened } = usePickerOpener(false, inputRef, dateTimePickerRef, undefined);
 
   const isTwelveHours = type === "use12Hours";
 

--- a/libs/date/src/TimeInput.tsx
+++ b/libs/date/src/TimeInput.tsx
@@ -153,7 +153,7 @@ export default function TimeInput({
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const timePickerRef = React.useRef<HTMLDivElement>(null);
-  const { opened, setOpened } = usePickerOpener(false, inputRef, timePickerRef, onBlur);
+  const { opened, setOpened } = usePickerOpener(false, inputRef, timePickerRef, undefined);
   const [showTimePickerMinutes, setShowTimePickerMinutes] = React.useState(false);
 
   const onOpen = () => {


### PR DESCRIPTION
## Basic information

* Tiller version: 1.6.0
* Module: date

## Bug description

The _onBlur_ prop for `DateInput` and `TimeInput` is not registering blur events. 
The _onBlur_ prop for `DateTimeInput` is executed twice instead of once.

### Related issue

Closes #113 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
