### PR TITLE
#117 Fix onBlur detection for date(time) input components

### DIFF
--- a/libs/date/src/DateInput.tsx
+++ b/libs/date/src/DateInput.tsx
@@ -176,7 +176,7 @@ type DateInputInputProps = {
   onClick: () => void;
 
   value: string;
-} & Omit<DateInputProps, "onChange" | "value" | "inputRef"> &
+} & Omit<DateInputProps, "onChange" | "value" | "inputRef" | "onBlur"> &
   TokenProps<"DateInput">;
 
 export default function DateInput({
@@ -217,7 +217,7 @@ export default function DateInput({
     numberOfMonths: 1,
     onDatesChange,
   });
-  const { opened, setOpened } = usePickerOpener(false, inputRef, datePickerRef, undefined);
+  const { opened, setOpened } = usePickerOpener(false, inputRef, datePickerRef, onBlur);
 
   const checkActiveMonthsValidity =
     value &&
@@ -269,7 +269,6 @@ export default function DateInput({
         onFocus={onOpen}
         focusedDate={value || null}
         allowClear={allowClear}
-        onBlur={onBlur}
         value={formattedValue || typedValue}
         onChange={onChange}
         onReset={onReset}
@@ -346,7 +345,6 @@ function DateInputInput({
       placeholder={getPlaceholder()}
       name={props.name}
       onClick={onClick}
-      onBlur={props.onBlur}
       onChange={(e) => onChange(e.target.value)}
       onReset={props.onReset}
       allowClear={allowClear}

--- a/libs/date/src/DateRangeInput.tsx
+++ b/libs/date/src/DateRangeInput.tsx
@@ -29,6 +29,7 @@ import { useIntlContext } from "@tiller-ds/intl";
 import { ComponentTokens, cx, TokenProps, useIcon, useTokens } from "@tiller-ds/theme";
 
 import DatePicker from "./DatePicker";
+import { usePickerOpener } from "./usePickerOpener";
 import { checkDatesInterval, formatDate, getDateFormatByLang, getMaskFromFormat } from "./utils";
 
 type DateTimeFormatOptionsOnly = "localeMatcher" | "weekday" | "year" | "month" | "day";
@@ -184,7 +185,7 @@ type DateRangeInputInputProps = {
   onClick: () => void;
 
   value: string | null;
-} & Omit<DateRangeInputProps, "start" | "end" | "onChange" | "inputRef"> &
+} & Omit<DateRangeInputProps, "start" | "end" | "onChange" | "inputRef" | "onBlur"> &
   TokenProps<"DateInput">;
 
 type DatePickerState = {
@@ -229,7 +230,10 @@ export default function DateRangeInput({
     endDate: end ?? null,
     focusedInput: start && !end ? END_DATE : START_DATE,
   });
-  const [opened, setOpened] = React.useState(false);
+
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const datePickerRef = React.useRef<HTMLDivElement>(null);
+  const { opened, setOpened } = usePickerOpener(false, inputRef, datePickerRef, onBlur);
 
   const onDatesChange = (data: OnDatesChangeProps) => {
     if (data.startDate && !data.endDate) {
@@ -303,8 +307,6 @@ export default function DateRangeInput({
     setOpened(true);
     inputRef.current?.focus();
   };
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const datePickerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     function listener(event: MouseEvent) {
@@ -385,7 +387,6 @@ export default function DateRangeInput({
         onFocus={onOpen}
         onChange={onChange}
         onReset={onReset}
-        onBlur={onBlur}
         allowClear={allowClear}
         value={typedValue}
         mask={getDateRangeMask()}

--- a/libs/date/src/DateTimeInput.tsx
+++ b/libs/date/src/DateTimeInput.tsx
@@ -194,7 +194,7 @@ export default function DateTimeInput({
   const [isDatePicker, setIsDatePicker] = React.useState<boolean>(true);
   const [showTimePickerMinutes, setShowTimePickerMinutes] = React.useState(false);
 
-  const { opened, setOpened } = usePickerOpener(false, inputRef, dateTimePickerRef, undefined);
+  const { opened, setOpened } = usePickerOpener(false, inputRef, dateTimePickerRef, onBlur);
 
   const isTwelveHours = type === "use12Hours";
 
@@ -411,7 +411,6 @@ export default function DateTimeInput({
         name={props.name}
         onClick={onOpen}
         onFocus={onOpen}
-        onBlur={onBlur}
         onChange={(e) => onChange(e.target.value)}
         onReset={onReset}
         allowClear={allowClear}

--- a/libs/date/src/TimeInput.tsx
+++ b/libs/date/src/TimeInput.tsx
@@ -153,7 +153,7 @@ export default function TimeInput({
 
   const inputRef = React.useRef<HTMLInputElement>(null);
   const timePickerRef = React.useRef<HTMLDivElement>(null);
-  const { opened, setOpened } = usePickerOpener(false, inputRef, timePickerRef, undefined);
+  const { opened, setOpened } = usePickerOpener(false, inputRef, timePickerRef, onBlur);
   const [showTimePickerMinutes, setShowTimePickerMinutes] = React.useState(false);
 
   const onOpen = () => {
@@ -330,7 +330,6 @@ export default function TimeInput({
         name={props.name}
         onClick={onOpen}
         onFocus={onOpen}
-        onBlur={onBlur}
         onChange={(e) => onChange(e.target.value)}
         onReset={onReset}
         allowClear={allowClear}

--- a/libs/formik-elements/src/TimeInputField.tsx
+++ b/libs/formik-elements/src/TimeInputField.tsx
@@ -53,6 +53,8 @@ export default function TimeInputField({ name, allowClear = true, ...props }: Ti
     helpers.setValue(null, shouldValidate);
   };
 
+  const onBlur = () => helpers.setTouched(true, shouldValidate);
+
   return (
     <TimeInput
       name={field.name}
@@ -60,6 +62,7 @@ export default function TimeInputField({ name, allowClear = true, ...props }: Ti
       error={meta.touched && (initialError.current ? initialError.current : meta.error)}
       onChange={onChange}
       onReset={onReset}
+      onBlur={onBlur}
       allowClear={allowClear}
       {...props}
     />


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.0
* Module: date

## Bug description

Detection of `onBlur` events occurs too early, which is especially noticable when using a form with validation which can trigger on date inputs. This can disrupt the UX experience on modals, for example, where the whole form shifts for a split second if this occurs (validation message shifts the components).

### Related issue

Closes #117 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
