### PR TITLE
#118 Fix logic for determining month input on date mask

### DIFF
--- a/libs/date/src/utils.tsx
+++ b/libs/date/src/utils.tsx
@@ -250,9 +250,12 @@ export const determineMonthInput = (value: string | null, position: number) => {
     if (value[position] === "0") {
       return /[1-9]/;
     }
+    if (value[position] === "1") {
+      return /[0-2]/;
+    }
   }
 
-  return /[0-2]/;
+  return /[0-9]/;
 };
 
 export const determineDayInput = (value: string | null, position: number) => {


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.0
* Module: date

## Bug description

Date mask sometimes behaves strange when clicking away from any date input components.
This is because of the logic behind determining the allowed month input number returning a false allowed number in a small number of use cases. In these cases the mask falls back to the range of numbers 0-2, thus removing the numbers which did not pass this test and glitching the date mask.

List of components: DateInput, DateRangeInput, DateTimeInput

### Related issue

Closes #118 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
