### PR TITLE
#123 Fix Figma tokens download link

### DIFF
--- a/storybook/src/base-documentation/ThemingAndCustomization.stories.mdx
+++ b/storybook/src/base-documentation/ThemingAndCustomization.stories.mdx
@@ -253,7 +253,7 @@ which support adding tokens to the token set (see the official page for best usa
 
 To import our token set, you need to have the aforementioned [Tokens Studio for Figma](https://docs.tokens.studio/) plugin installed.
 
-**The token set can be downloaded from [here](https://shorturl.at/duvwN)**.
+**The token set can be downloaded from [here](https://1drv.ms/u/s!AuB9bypaEEtMhSk2NJaJYdYumK4e?e=NBVF1y)**.
 
 Once you have the plugin installed and tokens downloaded, you can import the token set by following these steps:
 


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.0
* Module: docs

## Bug description

The link to Figma token set presented in the Theming and Customization page of the Storybook's [docs](https://croz-ltd.github.io/tiller/?path=/docs/theming-and-customization--page#importing-the-token-set) is not functional, which makes retrieving the token set impossible for end users.

### Related issue

Closes #123 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
