### PR TITLE
#137 Fix external value change consistency for DateInputField and DateTimeInputField

### DIFF
--- a/libs/date/src/DateInput.tsx
+++ b/libs/date/src/DateInput.tsx
@@ -201,6 +201,12 @@ export default function DateInput({
   const formattedValue = value ? dateFns.format(value, finalDateFormat) : "";
   const [typedValue, setTypedValue] = React.useState<string>(formattedValue);
 
+  React.useEffect(() => {
+    if (inputRef.current !== document.activeElement) {
+      setTypedValue(formattedValue);
+    }
+  }, [formattedValue]);
+
   const onDatesChange = (data: OnDatesChangeProps) => {
     props.onChange(data.startDate);
     setTypedValue(dateFns.format(data.startDate as Date, finalDateFormat));

--- a/libs/date/src/DateTimeInput.tsx
+++ b/libs/date/src/DateTimeInput.tsx
@@ -311,6 +311,12 @@ export default function DateTimeInput({
   const formattedValue = value ? formatValue(value) : "";
   const [typedValue, setTypedValue] = React.useState<string>(formattedValue);
 
+  React.useEffect(() => {
+    if (inputRef.current !== document.activeElement) {
+      setTypedValue(formattedValue);
+    }
+  }, [formattedValue]);
+
   const mobile = (window.innerWidth < 768) as boolean;
 
   const dateIconClassName = cx({ [inputTokens.Icon.clickableTrailing]: !(props.disabled || props.readOnly) });


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.0
* Module: form-elements, formik-elements

## Bug description

Resetting the value for `DateInputField` and `DateTimeInputField` through Formik helpers resets the component state (field value), but not the visual representation of the value inside the field. 

The component should be consistent in its behaviour, detect when a value is changed externally and set its internal state accordingly if the field is NOT the currently focused element in the window.

### Related issue

Closes #137 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
