### PR TITLE
#131 Fix active state misalignment between SidebarNavigation and TopNavigation

### DIFF
--- a/libs/menu/src/SidebarNavigation.tsx
+++ b/libs/menu/src/SidebarNavigation.tsx
@@ -305,7 +305,7 @@ export function SidebarNavigationItem({
   const tokens = useTokens("SidebarNavigation", props.tokens);
   const location = useLocation();
 
-  const active = to !== undefined ? location.pathname === to : false;
+  const active = to !== undefined ? location.pathname.startsWith(to) : false;
   const cn = cx(
     className,
     tokens.item.master,


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.0
* Module: menu

## Bug description

`SidebarNavigation` and `TopNavigation` components are inconsistent in their checks for active item state:

 - `SidebarNavigation` strictly checks whether the pathname **is equal** to `to` prop
 - `TopNavigation` checks whether the pathname **starts with** `to` prop

The check behaviour should be consistent between these 2 components.

### Related issue

Closes #131 

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
