### PR TITLE
#142 Fix bug with listeners on DragZone and DragZoneField. Add exampl…

### DIFF
--- a/libs/upload/src/DragZone.tsx
+++ b/libs/upload/src/DragZone.tsx
@@ -135,6 +135,7 @@ export default function DragZone<T extends File>({
   send,
   enhancer,
   destinationOptions,
+  listeners,
   subtitle,
   title,
   url,
@@ -152,6 +153,7 @@ export default function DragZone<T extends File>({
           url={url}
           send={send}
           enhancer={enhancer}
+          listeners={listeners}
           destinationOptions={destinationOptions}
           allowMultiple={allowMultiple}
         >

--- a/storybook/src/formik-elements/DragZoneField.mdx
+++ b/storybook/src/formik-elements/DragZoneField.mdx
@@ -115,6 +115,12 @@ function MyBetterUploaderComponent() {
 }
 ```
 
+## Using listeners
+
+Uploady exposes a `listeners` prop which could enable you to intercept any of the steps in the upload process and react to them.
+Returning `false` from the listeners will cancel the file upload.
+Currently, it could be mostly usable for max size checks which can be seen in [With size limit story](/docs/component-library-formik-elements-dragzonefield--with-size-limit)
+
 <Stories includePrimary={true} />
 
 ## Drag Zone Props:

--- a/storybook/src/formik-elements/DragZoneField.stories.tsx
+++ b/storybook/src/formik-elements/DragZoneField.stories.tsx
@@ -23,11 +23,14 @@ import { IconButton } from "@tiller-ds/core";
 import { DragZoneField } from "@tiller-ds/formik-elements";
 import { Intl } from "@tiller-ds/intl";
 import { FileList, useFileUpload } from "@tiller-ds/upload";
+import { Icon } from "@tiller-ds/icons";
+
+import { UPLOADER_EVENTS } from "@rpldy/uploader";
+import { BatchItem } from "@rpldy/shared";
 
 import { FormikDecorator, useMockSender } from "../utils";
 
 import mdx from "./DragZoneField.mdx";
-import { Icon } from "@tiller-ds/icons";
 
 const name = "dragzonefield";
 const nameWithError = "nameWithError";
@@ -197,6 +200,30 @@ export const Disabled = () => {
       send={useMockSender.send}
       title={<Intl name="dragZoneTitle" />}
       disabled={true}
+    />
+  );
+};
+
+export const WithSizeLimit = () => {
+  const useFileUploadHook = useFileUpload();
+
+  const listeners = {
+    [UPLOADER_EVENTS.ITEM_START]: (item: BatchItem) => {
+      if (item.file.size > 2000000) {
+        // send notification / add error
+        return false;
+      }
+    }
+  };
+
+  return (
+    <DragZoneField
+      name={name}
+      hook={useFileUploadHook}
+      url={useMockSender.destination.url}
+      send={useMockSender.send}
+      title={<Intl name="dragZoneTitle" />}
+      listeners={listeners}
     />
   );
 };


### PR DESCRIPTION
…e story and update documentation

## Basic information

* Tiller version: 1.7.1
* Module: `@tiller-ds/upload`

## Description

### Summary

There was a bug where listeners prop wasn't sent down to uploady components.

### Related issue

Closes #142 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Docs change

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
