### PR TITLE
#145 Add withCredentials to upload components

### DIFF
--- a/libs/upload/src/DragZone.tsx
+++ b/libs/upload/src/DragZone.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { UploadyContext, useItemFinishListener, useItemStartListener } from "@rpldy/uploady";
+import {UploadyContext, useItemErrorListener, useItemFinishListener, useItemStartListener} from "@rpldy/uploady";
 import UploadDropZone from "@rpldy/upload-drop-zone";
 
 import { Field, FieldProps } from "@tiller-ds/form-elements";
@@ -27,6 +27,7 @@ import UploadyWrapper, { UploadyWrapperProps } from "./UploadyWrapper";
 
 import { UseFileUpload, File, defaultUploadResponseMapper } from "./useFileUpload";
 import { BatchItem } from "@rpldy/shared";
+import {isObject} from "lodash";
 
 export type DragZoneProps<T extends File> = {
   /**
@@ -112,6 +113,11 @@ type CustomUploadDropZoneContainerProps<T extends File> = {
   uploadIcon?: React.ReactElement;
 
   /**
+   * `withCredentials` flag on fetch requests for uploading
+   */
+  withCredentials?: boolean
+
+  /**
    * Custom additional styling applied to the component.
    */
   className?: string;
@@ -140,6 +146,7 @@ export default function DragZone<T extends File>({
   title,
   url,
   uploadIcon,
+  withCredentials,
   className,
   ...props
 }: DragZoneProps<T>) {
@@ -156,6 +163,7 @@ export default function DragZone<T extends File>({
           listeners={listeners}
           destinationOptions={destinationOptions}
           allowMultiple={allowMultiple}
+          withCredentials={withCredentials}
         >
           <UploadDropZone className={tokens.uploadyDropZone} onDragOverClassName={onDragOverClassName}>
             <CustomUploadDropZoneContainer

--- a/libs/upload/src/UploadButton.tsx
+++ b/libs/upload/src/UploadButton.tsx
@@ -30,8 +30,20 @@ import { BatchItem } from "@rpldy/shared";
 type Status = "idle" | "waiting" | "error" | "success";
 
 export type UploadButtonProps<T extends File> = {
+  /**
+   * Url on the backend which is called for saving files
+   */
   url: string;
+
+  /**
+   * Object return from {@link useFileUpload} hook, used internally for correct behaviour of the file
+   * upload
+   */
   hook: UseFileUpload<T>;
+
+  /**
+   * The color of the component.
+   */
   color?:
     | "primary"
     | "success"
@@ -51,10 +63,33 @@ export type UploadButtonProps<T extends File> = {
     | "teal"
     | "gray"
     | undefined;
+
+  /**
+   * Whether will user be able to upload multiple files at once
+   */
   allowMultiple?: boolean;
+
+  /**
+   * Is the UploadButton disabled
+   */
   disabled?: boolean;
+
+  /**
+   * Function which fired in case item upload failed.
+   */
   onError?: (message: string) => void;
+  /**
+   * Custom mapper for the backend response, used when a subclass of {@link File} is used to extend uploaded file data
+   * @param item file that is uploaded
+   * @param originalFileName original file name of the file (in case if the backend does a rename)
+   */
   mapUploadResponse?: (item: BatchItem, originalFileName: string) => T;
+
+  /**
+   * `withCredentials` flag on fetch requests for uploading
+   */
+  withCredentials?: boolean
+
   /**
    * UploadButton content
    */
@@ -128,6 +163,7 @@ export default function UploadButton<T extends File>({
   destinationOptions,
   allowMultiple = false,
   mapUploadResponse = defaultUploadResponseMapper as (item: BatchItem, originalFileName: string) => T,
+  withCredentials,
   listeners,
   ...props
 }: UploadButtonProps<T>) {
@@ -138,6 +174,7 @@ export default function UploadButton<T extends File>({
       enhancer={enhancer}
       destinationOptions={destinationOptions}
       allowMultiple={allowMultiple}
+      withCredentials={withCredentials}
       listeners={listeners}
     >
       <CustomUploadButton color={color} mapUploadResponse={mapUploadResponse} {...props} />

--- a/libs/upload/src/UploadyWrapper.tsx
+++ b/libs/upload/src/UploadyWrapper.tsx
@@ -57,6 +57,11 @@ export type UploadyWrapperProps = {
   allowMultiple?: boolean;
 
   /**
+   * `withCredentials` flag on fetch requests for uploading
+   */
+  withCredentials?: boolean
+
+  /**
    * UploadWrapper content
    */
   children?: JSX.Element[] | JSX.Element;
@@ -77,6 +82,7 @@ export default function UploadyWrapper({
   listeners,
   enhancer,
   destinationOptions,
+  withCredentials,
   children,
 }: UploadyWrapperProps) {
   const authorizedDestination: Destination = {
@@ -90,6 +96,7 @@ export default function UploadyWrapper({
       send={send}
       multiple={allowMultiple}
       listeners={listeners}
+      withCredentials={withCredentials}
       enhancer={enhancer}
     >
       {children}


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.1
* Module: upload

## Description

### Summary

Exposed `withCredentials` on all upload components

### Related issue

Closes #145 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
