### PR TITLE
#155 Fix syntax error on Tabs component

### DIFF
--- a/libs/core/src/Tabs.tsx
+++ b/libs/core/src/Tabs.tsx
@@ -262,7 +262,7 @@ function Tabs({
 
   return (
     <CustomTabsContext.Provider value={tabsContext}>
-      <ReachTabs defaultIndex={defaultIndex} index={index} onChnage={onTabChange}>
+      <ReachTabs defaultIndex={defaultIndex} index={index} onChange={onTabChange}>
         <WithScrollButtons shouldWrap={scrollButtons}>
           <TabList className={className}>
             <CustomTabs hasScrollButtons={scrollButtons} tokens={tokens}>


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.2
* Module: core

## Description

The syntax error in `Tabs` component was making the `onTabChange` prop unusable. By fixing this mistake the component should successfully invoke this prop when the component changes.

### Related issue

Closes #155

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
