### PR TITLE
#152 Fix validateDOMNesting warning when rendering Dropdown component

### DIFF
--- a/libs/menu/src/Dropdown.tsx
+++ b/libs/menu/src/Dropdown.tsx
@@ -102,7 +102,7 @@ function DropdownContent({ children, isExpanded, className }: DropdownContentPro
 }
 
 function DropdownButton({ children }: DropdownButtonProps) {
-  return <MenuButton>{children}</MenuButton>;
+  return <MenuButton as="menu">{children}</MenuButton>;
 }
 
 function DropdownItem({ children, ...props }: DropdownItemProps) {


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.3
* Module: core

## Description

Fixed warning rendered in console when using a DropdownMenu component.

### Related issue

Closes #152

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
