### PR TITLE
#160 Fix `visibleItemCount` consistency for `DropdownMenu` component

### DIFF
--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -137,7 +137,7 @@ export type InputProps = {
    * Custom icon for warning on input
    */
   warningIcon?: React.ReactElement;
-} & Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>, "onReset"> &
+} & Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>, "onReset" | "ref"> &
   InputTokens;
 
 export type InputIconProps = {

--- a/libs/form-elements/src/MaskedInput.tsx
+++ b/libs/form-elements/src/MaskedInput.tsx
@@ -95,7 +95,7 @@ export default function MaskedInput({
   return (
     <Input
       {...props}
-      inputRef={(props.inputRef as React.RefObject<HTMLInputElement>) || currentRef}
+      ref={props.inputRef || currentRef}
       name={name}
       id={id}
       data-testid={id}

--- a/libs/menu/src/DropdownMenu.tsx
+++ b/libs/menu/src/DropdownMenu.tsx
@@ -123,7 +123,7 @@ function DropdownMenu({
   ...props
 }: DropdownMenuMenuProps) {
   const tokens = useTokens("DropdownMenu", props.tokens);
-  const [itemHeight, setItemHeight] = useState(0);
+  const [itemHeight, setItemHeight] = useState(40);
 
   const iconClassName = cx(
     { [tokens.Icon.color.default]: iconColor === "default" },
@@ -247,23 +247,23 @@ function DropdownMenuContainer({
 
   const containerPadding: number = useMemo(() => {
     if (childrenContainerRef !== null && childrenContainerRef.current !== null) {
-      return parseInt(
-        getComputedStyle(childrenContainerRef.current as Element)
-          .getPropertyValue("padding-top")
-          .match(/\d{1,3}/g)?.[0] || "2",
-      );
+      const computedStyles = getComputedStyle(childrenContainerRef.current as Element);
+      const paddingTop = parseInt(computedStyles.getPropertyValue("padding-top").match(/\d{1,3}/g)?.[0] || "2");
+      const paddingBottom = parseInt(computedStyles.getPropertyValue("padding-bottom").match(/\d{1,3}/g)?.[0] || "2");
+
+      return paddingTop + paddingBottom;
     }
-    return 2;
+    return 4;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [childrenContainerRef.current]);
 
-  const getHeight = useCallback(() => {
+  const menuListHeight = useMemo(() => {
     if (itemHeight && visibleItemCount && Array.isArray(children) && children.length >= visibleItemCount) {
-      return itemHeight * visibleItemCount + containerPadding * 2;
+      return itemHeight * visibleItemCount + containerPadding;
     }
 
     if (itemHeight && Array.isArray(children)) {
-      return itemHeight * children.length + containerPadding * 2;
+      return itemHeight * children.length + containerPadding;
     }
   }, [children, containerPadding, itemHeight, visibleItemCount]);
 
@@ -272,7 +272,7 @@ function DropdownMenuContainer({
       <div
         className={menuInnerContainerClassName}
         style={{
-          height: `${getHeight()}px`,
+          height: `${menuListHeight}px`,
         }}
       >
         <menu className={menuContainerChildrenClassName} ref={childrenContainerRef}>

--- a/libs/menu/src/DropdownMenu.tsx
+++ b/libs/menu/src/DropdownMenu.tsx
@@ -15,8 +15,7 @@
  *
  */
 
-import * as React from "react";
-import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import React, { useCallback, useContext, useMemo, useRef, useState } from "react";
 
 import { Button, ButtonProps } from "@tiller-ds/core";
 import { ComponentTokens, cx, TokenProps, useIcon, useTokens } from "@tiller-ds/theme";


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.3
* Module: menu

## Description

Fixed `visibleItemCount` prop consistency when changing values for `DropdownMenu` component.

### Related issue

Closes #160 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
