### PR TITLE
#163 Fix `Modal`'s `DialogContent` warning

### DIFF
--- a/libs/alert/src/Modal.tsx
+++ b/libs/alert/src/Modal.tsx
@@ -184,8 +184,7 @@ function Modal<T = unknown>({ isOpen, onClose, state, icon, children, canDismiss
           <div className={tokens.Container.Overlay.outer}>
             <div className={overlayInnerClassName}>&nbsp;</div>
           </div>
-
-          <DialogContent className={contentContainerClassName}>
+          <DialogContent className={contentContainerClassName} aria-label="Dialog Content">
             {canDismiss && (
               <div className={tokens.Container.Content.dismiss}>
                 <ModalDismiss />


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.3
* Module: core

## Description

Fixed a `DialogContent` warning generated in the console when rendering a Modal component by adding an `aria-label` prop to `DialogContent`.



### Related issue

Closes #163

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
