### PR TITLE
#133 - Empty DataTable state custom message or content

### DIFF
--- a/libs/data-display/src/DataTable.tsx
+++ b/libs/data-display/src/DataTable.tsx
@@ -121,6 +121,11 @@ export type DataTableProps<T extends object> = {
    * Custom additional class name for the main container.
    */
   className?: string;
+
+  /**
+   * Content to be displayed when the dataset is empty.
+   */
+  emptyState?: React.ReactNode;
 } & DataTableTokensProps;
 
 type DataTableTokensProps = {
@@ -620,7 +625,11 @@ function DataTable<T extends object>({
               </thead>
             )}
             <tbody {...getTableBodyProps()}>
-              {rows.map((row, rowKey) => {
+            {props.emptyState && !data.length ?
+              <tr>
+                <td colSpan={visibleColumns.length}>{props.emptyState}</td>
+              </tr> :
+              rows.map((row, rowKey) => {
                 prepareRow(row);
 
                 const primaryCells = _.slice(row.cells, 0, columnChildrenSize);

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -21,7 +21,7 @@ import { range, slice } from "lodash";
 
 import { withDesign } from "storybook-addon-designs";
 
-import { Button, Card, IconButton, Link, Pagination, useLocalPagination } from "@tiller-ds/core";
+import { Button, Card, IconButton, Link, Pagination, Typography, useLocalPagination } from "@tiller-ds/core";
 import { DataTable, useDataTable, useLocalSummary } from "@tiller-ds/data-display";
 import { Icon } from "@tiller-ds/icons";
 import { DropdownMenu } from "@tiller-ds/menu";
@@ -345,6 +345,26 @@ export const Simple = () => (
     <DataTable.Column header="ID" accessor="id" />
     <DataTable.Column header="Name" accessor="name" />
   </DataTable>
+);
+
+export const WithEmptyState = () => (
+  <div className="p-8 bg-gray-100 h-screen">
+    <Card>
+      <Card.Body removeSpacing={true}>
+        <DataTable data={[]} emptyState={
+          <div className="my-10 flex justify-center items-center flex-col gap-3">
+            <Icon type="warning" variant="regular" className="text-3xl"/>
+            <Typography variant="h6">No results found.</Typography>
+            <Typography variant="subtext" className="text-center">Try adjusting your search or filter to
+              find<br/> what you are looking for.</Typography>
+          </div>
+        }>
+          <DataTable.Column header="ID" accessor="id"/>
+          <DataTable.Column header="Name" accessor="name" title="name"/>
+        </DataTable>
+      </Card.Body>
+    </Card>
+  </div>
 );
 
 export const WithFooter = () => (
@@ -939,6 +959,7 @@ const HideControls = {
 KitchenSink.argTypes = HideControls;
 EmptyKitchenSink.argTypes = HideControls;
 Simple.argTypes = HideControls;
+WithEmptyState.argTypes = HideControls;
 WithFooter.argTypes = HideControls;
 WithFooterUsingLocalSummary.argTypes = HideControls;
 WithClickableRows.argTypes = HideControls;

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -348,7 +348,7 @@ export const Simple = () => (
 );
 
 export const WithEmptyState = () => (
-  <div className="p-8 bg-gray-100 h-screen">
+  <div className="p-8 bg-gray-100">
     <Card>
       <Card.Body removeSpacing={true}>
         <DataTable data={[]} emptyState={


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.4
* Module: data-display

## Description
Add an option of displaying a custom content when the table is empty.

### Related issue

Closes #133 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
