### PR TITLE
#149 - DataTable sorting - hook proposal

### DIFF
--- a/libs/data-display/src/index.tsx
+++ b/libs/data-display/src/index.tsx
@@ -19,6 +19,8 @@ import { SortInfo as InternalSortInfo } from "./DataTable";
 
 export type SortInfo = InternalSortInfo;
 
+export { default as useSortableDataTable } from "./useSortableDataTable";
+
 export { default as Amount } from "./Amount";
 export { default as DataTable, useDataTable, useLocalSummary } from "./DataTable";
 export { default as DescriptionList } from "./DescriptionList";

--- a/libs/data-display/src/useSortableDataTable.tsx
+++ b/libs/data-display/src/useSortableDataTable.tsx
@@ -17,5 +17,5 @@ export default function useSortableDataTable<T, U extends keyof T>(initialData: 
     return sortInfo.sortDirection === "ASCENDING" ? sortedData : sortedData.reverse();
   };
 
-  return { sortedData: generateSortedData(), dataTableHook };
+  return { sortedData: generateSortedData(), dataTableState, dataTableHook };
 }

--- a/libs/data-display/src/useSortableDataTable.tsx
+++ b/libs/data-display/src/useSortableDataTable.tsx
@@ -1,0 +1,21 @@
+import _ from "lodash";
+
+import { useDataTable } from "./index";
+
+export default function useSortableDataTable<T, U extends keyof T>(initialData: T[], columnMapping: Record<U, string>) {
+  const [dataTableState, dataTableHook] = useDataTable();
+
+  const generateSortedData = () => {
+    const sortInfo = dataTableState.sortBy[0];
+
+    if (!sortInfo) {
+      return initialData;
+    }
+
+    const sortedData = _.sortBy(initialData, columnMapping[sortInfo.column as U]);
+
+    return sortInfo.sortDirection === "ASCENDING" ? sortedData : sortedData.reverse();
+  };
+
+  return { sortedData: generateSortedData(), dataTableHook };
+}

--- a/libs/data-display/src/useSortableDataTable.tsx
+++ b/libs/data-display/src/useSortableDataTable.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from "react";
+
 import { useDataTable } from "./index";
 
 export default function useSortableDataTable<T, U extends keyof T>(initialData: T[], columnMapping: Record<U, string>) {
   const [dataTableState, dataTableHook] = useDataTable();
 
-  const generateSortedData = () => {
+  const generateSortedData = useMemo(() => {
     const sortInstructions = dataTableState.sortBy;
 
     if (!sortInstructions || sortInstructions.length === 0) {
@@ -23,8 +25,10 @@ export default function useSortableDataTable<T, U extends keyof T>(initialData: 
       }
 
       return 0;
-    })
-  };
+    });
+  }, [dataTableState.sortBy]);
 
-  return { sortedData: generateSortedData(), dataTableState, dataTableHook };
+  return useMemo(() => {
+    return { sortedData: generateSortedData, dataTableState, dataTableHook };
+  }, [generateSortedData]);
 }

--- a/libs/data-display/src/useSortableDataTable.tsx
+++ b/libs/data-display/src/useSortableDataTable.tsx
@@ -1,20 +1,29 @@
-import _ from "lodash";
-
 import { useDataTable } from "./index";
 
 export default function useSortableDataTable<T, U extends keyof T>(initialData: T[], columnMapping: Record<U, string>) {
   const [dataTableState, dataTableHook] = useDataTable();
 
   const generateSortedData = () => {
-    const sortInfo = dataTableState.sortBy[0];
+    const sortInstructions = dataTableState.sortBy;
 
-    if (!sortInfo) {
+    if (!sortInstructions || sortInstructions.length === 0) {
       return initialData;
     }
 
-    const sortedData = _.sortBy(initialData, columnMapping[sortInfo.column as U]);
+    return [...initialData].sort((a, b) => {
+      for (const sortInfo of sortInstructions) {
+        const columnKey = columnMapping[sortInfo.column];
+        const compareResult = sortInfo.sortDirection === "ASCENDING" ? -1 : 1;
+        const aValue = a[columnKey];
+        const bValue = b[columnKey];
 
-    return sortInfo.sortDirection === "ASCENDING" ? sortedData : sortedData.reverse();
+        if (aValue !== bValue) {
+          return (aValue < bValue ? -1 : 1) * compareResult;
+        }
+      }
+
+      return 0;
+    })
   };
 
   return { sortedData: generateSortedData(), dataTableState, dataTableHook };

--- a/storybook/src/data-display/DataTable.mdx
+++ b/storybook/src/data-display/DataTable.mdx
@@ -119,9 +119,10 @@ import { DataTable, useSortableDataTable } from '@tiller-ds/data-display';
 // Define column mapping for custom sorting
 const columnMapping = {
   name: 'name',
+  surname: "surname",
 };
 
-const { dataTableHook, sortedData } = useSortableDataTable(smallData || [], columnMapping);
+const { dataTableHook, sortedData } = useSortableDataTable(allData || [], columnMapping);
 
 <DataTable
   data={sortedData}
@@ -131,10 +132,15 @@ const { dataTableHook, sortedData } = useSortableDataTable(smallData || [], colu
       column: 'name',
       sortDirection: 'ASCENDING',
     },
+    {
+      column: "surname",
+      sortDirection: "ASCENDING",
+    },
   ]}
 >
   <DataTable.Column header="ID" accessor="id" canSort={false} />
   <DataTable.Column header="Name" accessor="name" canSort={true} />
+  <DataTable.Column header="Surname" accessor="surname" canSort={true} />
 </DataTable>;
 ```
 

--- a/storybook/src/data-display/DataTable.mdx
+++ b/storybook/src/data-display/DataTable.mdx
@@ -111,6 +111,45 @@ Here is an example utilizing the `useMemo` hook. This specific logic is applied 
 
 Now you have a DataTable component with sorting enabled for the specified column, and you can implement your own sorting logic based on your application requirements.
 
+### useSortableDataTable hook
+The `@tiller-ds/data-display` package provides a datatable sorting hook that allows you to implement custom sorting logic for your table columns. Here's an example of using the sorting hook in a DataTable:
+```tsx
+import { DataTable, useSortableDataTable } from '@tiller-ds/data-display';
+
+// Define column mapping for custom sorting
+const columnMapping = {
+  name: 'name',
+};
+
+const { dataTableHook, sortedData } = useSortableDataTable(smallData || [], columnMapping);
+
+<DataTable
+  data={sortedData}
+  hook={dataTableHook}
+  defaultSortBy={[
+    {
+      column: 'name',
+      sortDirection: 'ASCENDING',
+    },
+  ]}
+>
+  <DataTable.Column header="ID" accessor="id" canSort={false} />
+  <DataTable.Column header="Name" accessor="name" canSort={true} />
+</DataTable>;
+```
+
+The sorting hook, `useSortableDataTable`, enhances the DataTable component by providing a mechanism for sorting logic.
+It takes the table data and a column mapping as input and returns the necessary hook and sorted data.
+The column mapping is an object where keys represent column names and values represent their corresponding data keys.
+
+The hook returns an object with two properties:
+- `dataTableHook`: the hook that should be passed to the `hook` prop of the DataTable component
+- `sortedData`: the data array that has been sorted
+
+Ensure that the `canSort` prop is set to `true` for columns that should be sortable. <br/>
+Default sorting behavior can be configured using the `defaultSortBy` prop on the DataTable component. <br/>
+You can use this hook to implement sorting for specific columns according to your requirements.
+
 ## Best Practices
 
 Data Tables should:

--- a/storybook/src/data-display/DataTable.mdx
+++ b/storybook/src/data-display/DataTable.mdx
@@ -156,6 +156,10 @@ Ensure that the `canSort` prop is set to `true` for columns that should be sorta
 Default sorting behavior can be configured using the `defaultSortBy` prop on the DataTable component. <br/>
 You can use this hook to implement sorting for specific columns according to your requirements.
 
+**Note:**
+When using this hook, be aware that it is designed for **client-side sorting**. While it provides flexibility, it may **not be optimal** for handling **larger datasets**. <br/>
+Client-side sorting can lead to performance issues with larger amounts of data. It is recommended to consider server-side sorting for improved performance in such cases.
+
 ## Best Practices
 
 Data Tables should:

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -95,7 +95,7 @@ type Item = {
 };
 
 const names = ["Emily", "Michael", "Sarah", "Matthew"];
-const surname = ["Moore", "Williams", "Brown", "Davis"];
+const surname = ["Moore", "Williams", "Brown", "Davis", "Aron"];
 const jobs = ["Nurse", "Teacher", "Software developer", "Lawyer"];
 const jobDescription = [
   "You will be tasked with caring for pediatric patients with a variety of health conditions and challenges as well as collaborating with physicians to provide the highest-quality care possible to each individual. As a registered nurse on staff, you will communicate orders to medical assistants and other team members and coordinate with staff and families to ensure the adherence to the attending physician’s instructions as well as proper care and disease control practices.",
@@ -1239,9 +1239,10 @@ export const WithDefaultAscendingSortByNameUsingHook = () => {
   // incl-code
   const columnMapping = {
     name: "name",
+    surname: "surname",
   };
 
-  const { dataTableHook, sortedData } = useSortableDataTable(smallData || [], columnMapping);
+  const { dataTableHook, sortedData } = useSortableDataTable(allData || [], columnMapping);
 
   return (
     <DataTable
@@ -1252,10 +1253,15 @@ export const WithDefaultAscendingSortByNameUsingHook = () => {
           column: "name",
           sortDirection: "ASCENDING",
         },
+        {
+          column: "surname",
+          sortDirection: "ASCENDING",
+        },
       ]}
     >
       <DataTable.Column header="ID" accessor="id" canSort={false} />
       <DataTable.Column header="Name" accessor="name" canSort={true} />
+      <DataTable.Column header="Surname" accessor="surname" canSort={true} />
     </DataTable>
   )
 };

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -22,7 +22,7 @@ import { range, slice } from "lodash";
 import { withDesign } from "storybook-addon-designs";
 
 import { Button, Card, IconButton, Link, Pagination, Typography, useLocalPagination } from "@tiller-ds/core";
-import { DataTable, useDataTable, useLocalSummary } from "@tiller-ds/data-display";
+import { DataTable, useDataTable, useLocalSummary, useSortableDataTable } from "@tiller-ds/data-display";
 import { Icon } from "@tiller-ds/icons";
 import { DropdownMenu } from "@tiller-ds/menu";
 import { defaultThemeConfig } from "@tiller-ds/theme";
@@ -1235,6 +1235,31 @@ export const WithDefaultAscendingSortByName = (args) => {
   );
 };
 
+export const WithDefaultAscendingSortByNameUsingHook = () => {
+  // incl-code
+  const columnMapping = {
+    name: "name",
+  };
+
+  const { dataTableHook, sortedData } = useSortableDataTable(smallData || [], columnMapping);
+
+  return (
+    <DataTable
+      data={sortedData}
+      hook={dataTableHook}
+      defaultSortBy={[
+        {
+          column: "name",
+          sortDirection: "ASCENDING",
+        },
+      ]}
+    >
+      <DataTable.Column header="ID" accessor="id" canSort={false} />
+      <DataTable.Column header="Name" accessor="name" canSort={true} />
+    </DataTable>
+  )
+};
+
 export const WithIconButtons = (args) => (
   <DataTable data={smallData}>
     <DataTable.Column header="ID" accessor="id" />
@@ -1440,6 +1465,7 @@ WithHorizontalScroll.argTypes = HideControls;
 WithHorizontalScrollAndFirstColumnFixed.argTypes = HideControls;
 WithHorizontalScrollAndLastColumnFixed.argTypes = HideControls;
 WithDefaultAscendingSortByName.argTypes = HideControls;
+WithDefaultAscendingSortByNameUsingHook.argTypes = HideControls;
 WithIconButtons.argTypes = HideControls;
 WithPrimaryAndSecondaryRows.argTypes = HideControls;
 WithPrimaryAndSecondaryRowsAndComplexValues.argTypes = HideControls;

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -1235,7 +1235,7 @@ export const WithDefaultAscendingSortByName = (args) => {
   );
 };
 
-export const WithDefaultAscendingSortByNameUsingHook = () => {
+export const WithDefaultAscendingSortUsingHook = () => {
   // incl-code
   const columnMapping = {
     name: "name",
@@ -1471,7 +1471,7 @@ WithHorizontalScroll.argTypes = HideControls;
 WithHorizontalScrollAndFirstColumnFixed.argTypes = HideControls;
 WithHorizontalScrollAndLastColumnFixed.argTypes = HideControls;
 WithDefaultAscendingSortByName.argTypes = HideControls;
-WithDefaultAscendingSortByNameUsingHook.argTypes = HideControls;
+WithDefaultAscendingSortUsingHook.argTypes = HideControls;
 WithIconButtons.argTypes = HideControls;
 WithPrimaryAndSecondaryRows.argTypes = HideControls;
 WithPrimaryAndSecondaryRowsAndComplexValues.argTypes = HideControls;


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.4
* Module: data-display

## Description
DataTable sorting made possible by providing a default sorting hook to ease and reduce development process.

### Related issue

Closes #149 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)
- Docs change

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
