### PR TITLE
#150 - NumberInputField Storybook documentation missing props

### DIFF
--- a/storybook/src/form-elements/NumberInput.mdx
+++ b/storybook/src/form-elements/NumberInput.mdx
@@ -35,3 +35,18 @@ to the component. This way, the format will be inferred from these props instead
 ## Number Input Props:
 
 <ArgsTable of={NumberInput} />
+
+**Note**: The `NumberInput` component inherits properties from `NumberFormatProps` in addition to its own specific props. Refer to the [documentation of `NumberFormatProps`](https://s-yadav.github.io/react-number-format/docs/numeric_format) for details on the inherited properties.
+
+### Excluded Properties
+
+Some properties from `NumberFormatProps` are excluded in `NumberInput`:
+
+- allowedDecimalSeparators
+- any
+- customInput
+- onValueChange
+- step
+- type
+- max
+- min

--- a/storybook/src/formik-elements/NumberInputField.mdx
+++ b/storybook/src/formik-elements/NumberInputField.mdx
@@ -1,6 +1,6 @@
 import { ArgsTable, Stories } from "@storybook/addon-docs";
 
-import { NumberInputField } from "@tiller-ds/formik-elements";
+import { NumberInput } from "@tiller-ds/form-elements";
 
 # Number Input Field
 
@@ -37,4 +37,19 @@ to the component. This way, the format will be inferred from these props instead
 
 ## Number Input Field Props:
 
-<ArgsTable of={NumberInputField} />
+<ArgsTable of={NumberInput} include={["className", "decimalSeparator", "disabled", "help", "label", "name", "placeholder", "required", "thousandSeparator" ]} />
+
+**Note**: The `NumberInputField` component inherits properties from both `NumberInputProps` and `NumberFormatProps` in addition to its own specific props. Refer to the [documentation of `NumberFormatProps`](https://s-yadav.github.io/react-number-format/docs/numeric_format) for details on the inherited properties.
+
+### Excluded Properties
+
+Some properties from `NumberFormatProps` are excluded in `NumberInput`:
+
+- allowedDecimalSeparators
+- any
+- customInput
+- onValueChange
+- step
+- type
+- max
+- min


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.4
* Module: formik-elements

## Description
All props available to NumberInputField are listed in Storybook docs.

### Related issue

Closes #150 

## Types of changes

- Docs change

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
