### PR TITLE
#178 Display DragZone upload progress

### DIFF
--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -862,9 +862,13 @@ const defaultComponentConfig = {
     },
     iconSize: 7,
     iconColor: `text-slate-400 group-hover:text-primary`,
-    customUploadDropZoneDescriptionContainer: "text-center space-y-1",
+    customUploadDropZoneDescriptionContainer: "flex flex-col text-center items-center space-y-1",
+    loading: {
+      master: "relative flex justify-center items-center text-slate-600 mx-auto my-px",
+      percentage: "absolute top-1.5 text-body text-xs",
+    },
     customUploadDropZoneTitle: {
-      master: "flex",
+      master: "flex cursor-pointer",
       fontSize: "text-base",
       fontWeight: "font-medium",
       color: "text-body-light",

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -863,7 +863,7 @@ const defaultComponentConfig = {
     iconSize: 7,
     iconColor: `text-slate-400 group-hover:text-primary`,
     customUploadDropZoneDescriptionContainer: "flex flex-col text-center items-center space-y-1",
-    loading: {
+    loader: {
       master: "relative flex justify-center items-center text-slate-600 mx-auto my-px",
       percentage: "absolute top-1.5 text-body text-xs",
     },

--- a/libs/upload/src/DragZone.tsx
+++ b/libs/upload/src/DragZone.tsx
@@ -321,10 +321,12 @@ export function DragZoneLoader({ uploadPercentage, spinner = true, percentage = 
     );
   }
 
+  const loaderClassName = cx(tokens.loader.master, `h-${tokens.iconSize}`);
+
   return (
-    <div className={tokens.loading.master}>
+    <div className={loaderClassName}>
       {spinner && <LoadingIcon size={tokens.iconSize} />}
-      {percentage && <span className={tokens.loading.percentage}>{uploadPercentage}%</span>}
+      {percentage && <span className={tokens.loader.percentage}>{uploadPercentage}%</span>}
     </div>
   );
 }

--- a/libs/upload/src/index.tsx
+++ b/libs/upload/src/index.tsx
@@ -27,6 +27,6 @@ export type File = InternalFile;
 
 export { default as useFileUpload } from "./useFileUpload";
 
-export { default as DragZone } from "./DragZone";
+export { default as DragZone, DragZoneLoader } from "./DragZone";
 export { default as FileList } from "./FileList";
 export { default as UploadButton } from "./UploadButton";

--- a/storybook/src/formik-elements/DragZoneField.stories.tsx
+++ b/storybook/src/formik-elements/DragZoneField.stories.tsx
@@ -85,7 +85,6 @@ export const Simple = () => {
 
 export const WithSpinnerOnly = () => {
   // incl-code
-  // hook initialization
   const useFileUploadHook = useFileUpload();
 
   return (
@@ -102,7 +101,6 @@ export const WithSpinnerOnly = () => {
 
 export const WithPercentageOnly = () => {
   // incl-code
-  // hook initialization
   const useFileUploadHook = useFileUpload();
 
   return (
@@ -119,7 +117,6 @@ export const WithPercentageOnly = () => {
 
 export const WithNoLoader = () => {
   // incl-code
-  // hook initialization
   const useFileUploadHook = useFileUpload();
 
   return (
@@ -202,7 +199,6 @@ export const WithFileList = () => {
 
 export const WithFileListAndCustomLoader = () => {
   // incl-code
-  // hook initialization
   const useFileUploadHook = useFileUpload();
 
   return (

--- a/storybook/src/formik-elements/DragZoneField.stories.tsx
+++ b/storybook/src/formik-elements/DragZoneField.stories.tsx
@@ -22,7 +22,7 @@ import { withDesign } from "storybook-addon-designs";
 import { IconButton } from "@tiller-ds/core";
 import { DragZoneField } from "@tiller-ds/formik-elements";
 import { Intl } from "@tiller-ds/intl";
-import { FileList, useFileUpload } from "@tiller-ds/upload";
+import { DragZoneLoader, FileList, useFileUpload } from "@tiller-ds/upload";
 import { Icon } from "@tiller-ds/icons";
 
 import { UPLOADER_EVENTS } from "@rpldy/uploader";
@@ -83,6 +83,40 @@ export const Simple = () => {
   );
 };
 
+export const WithSpinnerOnly = () => {
+  // incl-code
+  // hook initialization
+  const useFileUploadHook = useFileUpload();
+
+  return (
+    <DragZoneField
+      name={name}
+      hook={useFileUploadHook}
+      url={useMockSender.destination.url}
+      send={useMockSender.send}
+      title={<Intl name="dragZoneTitle" />}
+      loader={() => <DragZoneLoader percentage={false} />}
+    />
+  );
+};
+
+export const WithNoLoader = () => {
+  // incl-code
+  // hook initialization
+  const useFileUploadHook = useFileUpload();
+
+  return (
+    <DragZoneField
+      name={name}
+      hook={useFileUploadHook}
+      url={useMockSender.destination.url}
+      send={useMockSender.send}
+      title={<Intl name="dragZoneTitle" />}
+      loader={null}
+    />
+  );
+};
+
 export const WithSubtitle = () => {
   // incl-code
   const useFileUploadHook = useFileUpload();
@@ -128,6 +162,44 @@ export const WithFileList = () => {
         send={useMockSender.send}
         allowMultiple={true}
         title={<Intl name="dragZoneTitle" />}
+      />
+      <FileList hook={useFileUploadHook}>
+        {(file, helpers) => (
+          <FileList.Header>
+            <FileList.Header.Name>{file.name}</FileList.Header.Name>
+            <FileList.Header.Action>
+              <IconButton
+                icon={<Icon type="trash" />}
+                label={<Intl name="delete" />}
+                onClick={() => {
+                  return helpers.deleteFile(file);
+                }}
+              />
+            </FileList.Header.Action>
+          </FileList.Header>
+        )}
+      </FileList>
+    </div>
+  );
+};
+
+export const WithFileListAndCustomLoader = () => {
+  // incl-code
+  // hook initialization
+  const useFileUploadHook = useFileUpload();
+
+  return (
+    <div>
+      <DragZoneField
+        name={name}
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        allowMultiple={true}
+        title={<Intl name="dragZoneTitle" />}
+        loader={(percentage) => (
+          <span className="animate-pulse text-body-light h-7 my-px ">Uploading... {percentage}%</span>
+        )}
       />
       <FileList hook={useFileUploadHook}>
         {(file, helpers) => (

--- a/storybook/src/formik-elements/DragZoneField.stories.tsx
+++ b/storybook/src/formik-elements/DragZoneField.stories.tsx
@@ -100,6 +100,23 @@ export const WithSpinnerOnly = () => {
   );
 };
 
+export const WithPercentageOnly = () => {
+  // incl-code
+  // hook initialization
+  const useFileUploadHook = useFileUpload();
+
+  return (
+    <DragZoneField
+      name={name}
+      hook={useFileUploadHook}
+      url={useMockSender.destination.url}
+      send={useMockSender.send}
+      title={<Intl name="dragZoneTitle" />}
+      loader={(uploadPercentage) => <DragZoneLoader spinner={false} uploadPercentage={uploadPercentage} />}
+    />
+  );
+};
+
 export const WithNoLoader = () => {
   // incl-code
   // hook initialization

--- a/storybook/src/upload/DragZone.stories.tsx
+++ b/storybook/src/upload/DragZone.stories.tsx
@@ -92,7 +92,7 @@ export const WithPercentageOnly = () => {
         url={useMockSender.destination.url}
         send={useMockSender.send}
         title={<Intl name="dragZoneTitle" />}
-        loader={() => <DragZoneLoader spinner={false} />}
+        loader={(uploadPercentage) => <DragZoneLoader spinner={false} uploadPercentage={uploadPercentage} />}
       />
       Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
     </>

--- a/storybook/src/upload/DragZone.stories.tsx
+++ b/storybook/src/upload/DragZone.stories.tsx
@@ -64,7 +64,6 @@ export const Simple = () => {
 
 export const WithSpinnerOnly = () => {
   // incl-code
-  // hook initialization
   const useFileUploadHook = useFileUpload([], true);
 
   return (
@@ -192,13 +191,11 @@ export const WithFileList = () => {
 
 export const WithFileListAndCustomLoader = () => {
   // incl-code
-  // files list
   const initialFiles: File[] = [
     { id: "1", name: "test1.pdf", status: "finished" },
     { id: "2", name: "test2.pdf", status: "finished" },
   ];
 
-  // hook initialization
   const useFileUploadHook = useFileUpload(initialFiles, true);
 
   return (
@@ -304,7 +301,6 @@ export const Disabled = () => {
 
 export const WithManualFileTracking = () => {
   // incl-code
-  // hook initialization
   const fileUploadHookValue = useFileUpload();
   const [uploadedFileIds, setUploadedFileIds] = React.useState<string[]>([]);
 

--- a/storybook/src/upload/DragZone.stories.tsx
+++ b/storybook/src/upload/DragZone.stories.tsx
@@ -22,7 +22,7 @@ import { withDesign } from "storybook-addon-designs";
 import { IconButton } from "@tiller-ds/core";
 import { Icon } from "@tiller-ds/icons";
 import { Intl } from "@tiller-ds/intl";
-import { DragZone, FileList, useFileUpload, File } from "@tiller-ds/upload";
+import { DragZone, FileList, useFileUpload, File, DragZoneLoader } from "@tiller-ds/upload";
 
 import { beautifySource, useMockSender } from "../utils";
 
@@ -47,45 +47,108 @@ export default {
 
 export const Simple = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  const useFileUploadHook = useFileUpload([], true);
 
   return (
-    <DragZone
-      hook={useFileUploadHook}
-      url={useMockSender.destination.url}
-      send={useMockSender.send}
-      title={<Intl name="dragZoneTitle" />}
-    />
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
+  );
+};
+
+export const WithSpinnerOnly = () => {
+  // incl-code
+  // hook initialization
+  const useFileUploadHook = useFileUpload([], true);
+
+  return (
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        loader={() => <DragZoneLoader percentage={false} />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
+  );
+};
+
+export const WithPercentageOnly = () => {
+  // incl-code
+  const useFileUploadHook = useFileUpload([], true);
+
+  return (
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        loader={() => <DragZoneLoader spinner={false} />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
+  );
+};
+
+export const WithNoLoader = () => {
+  // incl-code
+  const useFileUploadHook = useFileUpload([], true);
+
+  return (
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        loader={null}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
   );
 };
 
 export const WithSubtitle = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  const useFileUploadHook = useFileUpload([], true);
 
   return (
-    <DragZone
-      hook={useFileUploadHook}
-      url={useMockSender.destination.url}
-      send={useMockSender.send}
-      title={<Intl name="dragZoneTitle" />}
-      subtitle={<Intl name="dragZoneSubtitle" />}
-    />
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
   );
 };
 
 export const WithMultipleFiles = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  const useFileUploadHook = useFileUpload([], true);
 
   return (
-    <DragZone
-      hook={useFileUploadHook}
-      url={useMockSender.destination.url}
-      send={useMockSender.send}
-      allowMultiple={true}
-      title={<Intl name="dragZoneTitle" />}
-    />
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        allowMultiple={true}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
   );
 };
 
@@ -96,7 +159,7 @@ export const WithFileList = () => {
     { id: "2", name: "test2.pdf", status: "finished" },
   ];
 
-  const useFileUploadHook = useFileUpload(initialFiles);
+  const useFileUploadHook = useFileUpload(initialFiles, true);
 
   return (
     <div>
@@ -127,54 +190,106 @@ export const WithFileList = () => {
   );
 };
 
-export const WithLabel = () => {
+export const WithFileListAndCustomLoader = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  // files list
+  const initialFiles: File[] = [
+    { id: "1", name: "test1.pdf", status: "finished" },
+    { id: "2", name: "test2.pdf", status: "finished" },
+  ];
+
+  // hook initialization
+  const useFileUploadHook = useFileUpload(initialFiles, true);
 
   return (
-    <DragZone
-      hook={useFileUploadHook}
-      url={useMockSender.destination.url}
-      send={useMockSender.send}
-      title={<Intl name="dragZoneTitle" />}
-      label={<Intl name="label" />}
-    />
+    <div>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        allowMultiple={true}
+        title={<Intl name="dragZoneTitle" />}
+        loader={(percentage) => (
+          <span className="animate-pulse text-body-light h-7 my-px ">Uploading... {percentage}%</span>
+        )}
+      />
+      <FileList hook={useFileUploadHook}>
+        {(file, helpers) => (
+          <FileList.Header>
+            <FileList.Header.Name>{file.name}</FileList.Header.Name>
+            <FileList.Header.Action>
+              <IconButton
+                icon={<Icon type="trash" />}
+                label={<Intl name="delete" />}
+                onClick={() => {
+                  return helpers.deleteFile(file);
+                }}
+              />
+            </FileList.Header.Action>
+          </FileList.Header>
+        )}
+      </FileList>
+    </div>
+  );
+};
+
+export const WithLabel = () => {
+  // incl-code
+  const useFileUploadHook = useFileUpload([], true);
+
+  return (
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        label={<Intl name="label" />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
   );
 };
 
 export const WithHelp = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  const useFileUploadHook = useFileUpload([], true);
 
   return (
-    <DragZone
-      hook={useFileUploadHook}
-      url={useMockSender.destination.url}
-      send={useMockSender.send}
-      title={<Intl name="dragZoneTitle" />}
-      help={<Intl name="help" />}
-    />
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        help={<Intl name="help" />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
   );
 };
 
 export const WithError = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  const useFileUploadHook = useFileUpload([], true);
 
   return (
-    <DragZone
-      hook={useFileUploadHook}
-      url={useMockSender.destination.url}
-      send={useMockSender.send}
-      title={<Intl name="dragZoneTitle" />}
-      error={<Intl name="error" />}
-    />
+    <>
+      <DragZone
+        hook={useFileUploadHook}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        error={<Intl name="error" />}
+      />
+      Uploaded: {useFileUploadHook.uploadedFiles.map((file) => file.originalFileName).join(", ") || "None"}
+    </>
   );
 };
 
 export const Disabled = () => {
   // incl-code
-  const useFileUploadHook = useFileUpload();
+  const useFileUploadHook = useFileUpload([], true);
 
   return (
     <DragZone
@@ -184,5 +299,44 @@ export const Disabled = () => {
       title={<Intl name="dragZoneTitle" />}
       disabled={true}
     />
+  );
+};
+
+export const WithManualFileTracking = () => {
+  // incl-code
+  // hook initialization
+  const fileUploadHookValue = useFileUpload();
+  const [uploadedFileIds, setUploadedFileIds] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    fileUploadHookValue.onUpdateCallback((added, removed) => {
+      setUploadedFileIds((oldFileIds) => {
+        let newFileIds = [...oldFileIds];
+        if (added !== undefined) {
+          if (typeof added === "string") {
+            newFileIds.push(added);
+          }
+        }
+        if (removed !== undefined) {
+          newFileIds = newFileIds.filter((id) => id !== removed);
+        }
+        // update internal file id list with correct updated list
+        fileUploadHookValue.onUploadedFileIds(newFileIds);
+        return newFileIds;
+      });
+    });
+  }, []);
+
+  return (
+    <>
+      <DragZone
+        hook={fileUploadHookValue}
+        url={useMockSender.destination.url}
+        send={useMockSender.send}
+        title={<Intl name="dragZoneTitle" />}
+        allowMultiple={true}
+      />
+      Uploaded ids: {uploadedFileIds.join(", ") || "None"}
+    </>
   );
 };


### PR DESCRIPTION
## Basic information

* Tiller version: 1.7.4
* Module: upload

## Description
Added `loader` prop to `DragZone` component which defaults to a spinner and percentage indicators when uploading file(s).
Updated stories to show different variations of using the `loader` prop, including using a custom loader or no loader at all.

### Related issue

Closes #178 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)
- Docs change

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
