### PR TITLE
#193 Fix Select and Autocomplete (multiple selection) input references

### DIFF
--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -986,7 +986,7 @@ function Autocomplete<T extends {}>({
         })}
         {...getComboboxProps({}, { suppressRefError: true })}
       />
-      {allowMultiple && <input type="hidden" name={name} />}
+      {allowMultiple && <input className="absolute w-0 h-0" name={name} />}
       <Popover
         className="z-50"
         targetRef={toggleRef}

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -409,7 +409,7 @@ function Select<T>({
         >
           <div className={tokens.Button.container}>
             <div className={tokens.Button.value}>{valueLabel}</div>
-            <input className={tokens.Button.input} ref={inputRef} tabIndex={-1} />
+            <input name={name} className={tokens.Button.input} ref={inputRef} tabIndex={-1} />
             <div className={tokens.Loading.container}>
               {loading && <div className={loadingInnerClassName}>{loadingIcon}</div>}
               {error && warningIcon}


### PR DESCRIPTION
## Basic information

* Tiller version: 1.8.0
* Module: selectors

## Description

Fixed non-existent `name` attribute on `Select` component which allows the `useScrollToError` hook to catch the element for error detection.
Fixed `Autocomplete` (multiple selection) input styling from `hidden` to `w-0 h-0 `so that the element exists and can be found by the hook.

### Related issue

Closes #193 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
