### PR TITLE
#191 Fix and improve children handling on DropdownMenu

### DIFF
--- a/libs/menu/src/DropdownMenu.tsx
+++ b/libs/menu/src/DropdownMenu.tsx
@@ -189,7 +189,7 @@ export function DropdownMenuItem({
   const { setItemHeight } = useContext(DropdownContext);
 
   React.useEffect(() => {
-    if (setItemHeight && itemRef.current) {
+    if (setItemHeight && itemRef.current && itemRef.current.clientHeight > 0) {
       setItemHeight(itemRef.current.clientHeight);
     }
   }, [setItemHeight]);
@@ -258,12 +258,11 @@ function DropdownMenuContainer({
   }, [childrenContainerRef.current]);
 
   const menuListHeight = useMemo(() => {
-    if (itemHeight && visibleItemCount && Array.isArray(children) && children.length >= visibleItemCount) {
-      return itemHeight * visibleItemCount + containerPadding;
-    }
+    const filteredChildren = Array.isArray(children) && children.filter((child) => typeof child !== "boolean");
 
-    if (itemHeight && Array.isArray(children)) {
-      return itemHeight * children.length + containerPadding;
+    if (itemHeight && Array.isArray(filteredChildren)) {
+      const itemCount = Math.min(filteredChildren.length, visibleItemCount || filteredChildren.length);
+      return itemHeight * itemCount + containerPadding;
     }
   }, [children, containerPadding, itemHeight, visibleItemCount]);
 
@@ -272,7 +271,7 @@ function DropdownMenuContainer({
       <div
         className={menuInnerContainerClassName}
         style={{
-          height: `${menuListHeight}px`,
+          height: visibleItemCount ? `${menuListHeight}px` : undefined,
         }}
       >
         <menu className={menuContainerChildrenClassName} ref={childrenContainerRef}>

--- a/storybook/src/menu/DropdownMenu.stories.tsx
+++ b/storybook/src/menu/DropdownMenu.stories.tsx
@@ -16,14 +16,16 @@
  */
 
 import * as React from "react";
+import { useState } from "react";
 
 import { withDesign } from "storybook-addon-designs";
 
+import { NumberInput } from "@tiller-ds/form-elements";
 import { Icon, iconTypes } from "@tiller-ds/icons";
 import { DropdownMenu } from "@tiller-ds/menu";
 import { defaultThemeConfig } from "@tiller-ds/theme";
 
-import { extendedColors, getChangedTokensFromSource, showFactoryDecorator } from "../utils";
+import { beautifySource, extendedColors, getChangedTokensFromSource, showFactoryDecorator } from "../utils";
 
 import mdx from "./DropdownMenu.mdx";
 
@@ -33,12 +35,12 @@ export default {
   parameters: {
     docs: {
       page: mdx,
-      source: { type: "dynamic", excludeDecorators: true },
+      source: { type: "auto", excludeDecorators: true },
       transformSource: (source) => {
         const correctedSource = source
           .replace(/DropdownMenuItem/g, "DropdownMenu.Item")
           .replace(/function noRefCheck\(\)\s\{\}/g, "() => {}");
-        return getChangedTokensFromSource(correctedSource, "DropdownMenu");
+        return beautifySource(getChangedTokensFromSource(correctedSource, "DropdownMenu"), "DropdownMenu");
       },
     },
     design: {
@@ -197,6 +199,36 @@ export const WithScrollbar = () => (
   </DropdownMenu>
 );
 
+export const WithDefinedVisibleItemCount = () => {
+  // incl-code
+  const [visibleCount, setVisibleCount] = useState<number | undefined>(5);
+
+  return (
+    <div className="flex space-x-4 items-end">
+      <DropdownMenu title="User" visibleItemCount={visibleCount}>
+        <DropdownMenu.Item onSelect={() => {}}>Account</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Account Info</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Account Messages</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Account Alerts</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Account Notifications</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Account Settings</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Account Pictures</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Support</DropdownMenu.Item>
+        <DropdownMenu.Item onSelect={() => {}}>Sign Out</DropdownMenu.Item>
+      </DropdownMenu>
+      <NumberInput
+        type="number"
+        allowNegative={false}
+        name="count"
+        label="Visible item count"
+        className="w-32"
+        value={String(visibleCount)}
+        onChange={setVisibleCount}
+      />
+    </div>
+  );
+};
+
 export const WithLeadingIcon = () => (
   <DropdownMenu title="User" iconPlacement="leading">
     <DropdownMenu.Item onSelect={() => {}}>Account settings</DropdownMenu.Item>
@@ -270,6 +302,7 @@ const HideControls = {
 
 Simple.argTypes = HideControls;
 WithScrollbar.argTypes = HideControls;
+WithDefinedVisibleItemCount.argTypes = HideControls;
 WithLeadingIcon.argTypes = HideControls;
 AsIcon.argTypes = HideControls;
 WithLongItems.argTypes = HideControls;


### PR DESCRIPTION
## Basic information

* Tiller version: 1.8.0
* Module: menu

## Description

Fixed the issue of incorrect child detection in the DropdownMenu component by implementing a filtering mechanism to exclude conditionally rendered items that should not appear in the children array. 

Fixed the issue of incorrect menu height when `visibleItemCount` prop is set to a value larger than the length of the children array.

Added a story to showcase the usage of `DropdownMenu` with `visibleItemCount` enabled.

### Related issue

Closes #191 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
