### PR TITLE
#159 Add empty string support as `thousandSeparator` for NumberInput(Field)

### DIFF
--- a/libs/form-elements/src/NumberInput.tsx
+++ b/libs/form-elements/src/NumberInput.tsx
@@ -124,7 +124,7 @@ export default function NumberInput({
     );
   }
 
-  if (usesDecimalSeparator && decimalSeparator === "") {
+  if (usesDecimalSeparator && decimalSeparator?.trim() === "") {
     throw new Error(
       "When providing a decimalSeparator prop, it must be a valid character (e.g., '.', ',') to separate decimal places. An empty string ('') is not allowed.",
     );

--- a/libs/form-elements/src/NumberInput.tsx
+++ b/libs/form-elements/src/NumberInput.tsx
@@ -115,14 +115,23 @@ export default function NumberInput({
 }: NumberInputProps) {
   const intlContext = useIntlContext();
   const id = `numberformat-${name}`;
+  const usesDecimalSeparator = decimalSeparator !== undefined;
+  const usesThousandSeparator = thousandSeparator !== undefined;
 
-  if (!intlContext && (!decimalSeparator || !thousandSeparator)) {
+  if (!intlContext && (!usesDecimalSeparator || !usesThousandSeparator)) {
     throw new Error(
-      "You must pass decimalSeparator and thousandSeparator props if you are using the NumberInput component without IntlProvider.",
+      "You must pass decimalSeparator and/or thousandSeparator props if you are using the NumberInput component without IntlProvider.",
     );
   }
+
+  if (usesDecimalSeparator && decimalSeparator === "") {
+    throw new Error(
+      "When providing a decimalSeparator prop, it must be a valid character (e.g., '.', ',') to separate decimal places. An empty string ('') is not allowed.",
+    );
+  }
+
   const getFinalDecimalSeparator = () => {
-    if (decimalSeparator && thousandSeparator) {
+    if (usesDecimalSeparator) {
       return decimalSeparator;
     }
     if (intlContext) {
@@ -132,7 +141,7 @@ export default function NumberInput({
   };
 
   const getFinalThousandSeparator = () => {
-    if (decimalSeparator && thousandSeparator) {
+    if (usesThousandSeparator) {
       return thousandSeparator;
     }
     if (intlContext) {

--- a/storybook/src/form-elements/NumberInput.mdx
+++ b/storybook/src/form-elements/NumberInput.mdx
@@ -27,8 +27,9 @@ automatically inferred from the `locale` prop of `IntlProvider`.
 
 ## Usage without IntlProvider
 
-If you wish to use this component without `IntlProvider`, you can do so by passing `thousandSeparator` and `decimalSeparator` props
+If you wish to use this component without `IntlProvider`, you can do so by passing `decimalSeparator` and/or `thousandSeparator` props
 to the component. This way, the format will be inferred from these props instead of the `locale` prop of `IntlProvider`.
+If only one of these 2 props is defined, the other one will be inferred from `react-number-format` defaults.
 
 <Stories includePrimary={true} />
 

--- a/storybook/src/formik-elements/NumberInputField.mdx
+++ b/storybook/src/formik-elements/NumberInputField.mdx
@@ -30,14 +30,28 @@ automatically inferred from the `locale` prop of `IntlProvider`.
 
 ## Usage without IntlProvider
 
-If you wish to use this component without `IntlProvider`, you can do so by passing `thousandSeparator` and `decimalSeparator` props
+If you wish to use this component without `IntlProvider`, you can do so by passing `decimalSeparator` and/or `thousandSeparator` props
 to the component. This way, the format will be inferred from these props instead of the `locale` prop of `IntlProvider`.
+If only one of these 2 props is defined, the other one will be inferred from `react-number-format` defaults.
 
 <Stories includePrimary={true} />
 
 ## Number Input Field Props:
 
-<ArgsTable of={NumberInput} include={["className", "decimalSeparator", "disabled", "help", "label", "name", "placeholder", "required", "thousandSeparator" ]} />
+<ArgsTable
+  of={NumberInput}
+  include={[
+    "className",
+    "decimalSeparator",
+    "disabled",
+    "help",
+    "label",
+    "name",
+    "placeholder",
+    "required",
+    "thousandSeparator",
+  ]}
+/>
 
 **Note**: The `NumberInputField` component inherits properties from both `NumberInputProps` and `NumberFormatProps` in addition to its own specific props. Refer to the [documentation of `NumberFormatProps`](https://s-yadav.github.io/react-number-format/docs/numeric_format) for details on the inherited properties.
 


### PR DESCRIPTION
## Basic information

* Tiller version: 1.8.0
* Module: form-elements, formik-elements

## Description
Added better checking for `decimalSeparator` and `thousandSeparator` definition on `NumberInput(Field)` component and allowed empty string value ("") for `decimalSeparator` prop.

Added a check for the validity of `thousandSeparator` prop and implemented an error message if an empy string ("") is defined for this prop.

### Related issue

Closes #159 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
