### PR TITLE
#198 Fix redundant `DateRangeInput(Field)` focus

### DIFF
--- a/libs/date/src/DateRangeInput.tsx
+++ b/libs/date/src/DateRangeInput.tsx
@@ -234,6 +234,7 @@ export default function DateRangeInput({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const datePickerRef = React.useRef<HTMLDivElement>(null);
   const { opened, setOpened } = usePickerOpener(false, inputRef, datePickerRef, onBlur);
+  const previousOpened = React.useRef(false);
 
   const onDatesChange = (data: OnDatesChangeProps) => {
     if (data.startDate && !data.endDate) {
@@ -248,6 +249,7 @@ export default function DateRangeInput({
       setDatePickerState({ startDate: null, endDate: null, focusedInput: START_DATE });
       props.onChange(data.startDate, data.endDate);
       setOpened(false);
+      previousOpened.current = true;
     }
   };
 
@@ -299,9 +301,10 @@ export default function DateRangeInput({
       datePickerState.startDate === null &&
       datePickerState.endDate === null &&
       datePickerState.focusedInput === START_DATE &&
-      (start || end)
+      previousOpened.current
     ) {
       inputRef.current?.focus();
+      previousOpened.current = false;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [start, end]);
@@ -314,6 +317,7 @@ export default function DateRangeInput({
       datePicker.onDateFocus(start || minDate || (null as unknown as Date));
     }
     setOpened(true);
+    previousOpened.current = false;
     inputRef.current?.focus();
   };
 
@@ -327,6 +331,7 @@ export default function DateRangeInput({
 
       if (opened && isOutsideInput && isOutsideDatePicker) {
         setOpened(false);
+        previousOpened.current = true;
       }
     }
 
@@ -353,6 +358,7 @@ export default function DateRangeInput({
       } else if (startingDate && endingDate) {
         if (closeAfterEntry) {
           setOpened(false);
+          previousOpened.current = true;
         }
         datePicker.onDateFocus(endingDate);
         props.onChange(startingDate, endingDate);
@@ -372,6 +378,7 @@ export default function DateRangeInput({
     inputRef.current?.focus();
     setTypedValue("");
     setOpened(false);
+    previousOpened.current = true;
   };
 
   const getDateRangeMask = () => {


### PR DESCRIPTION
## Basic information

* Tiller version: 1.8.0
* Module: form-elements

## Description

Fixed redundant focusing of `DateRangeInput(Field)` component when shifting away from the component after selection of dates from the date picker.

### Related issue

Closes #198 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
