### PR TITLE
#204 RichTextEditor semantic error TS2569

### DIFF
--- a/libs/form-elements-advanced/src/RichTextEditor.tsx
+++ b/libs/form-elements-advanced/src/RichTextEditor.tsx
@@ -677,8 +677,7 @@ function getHtmlOfEditor(editor: LexicalEditor): string {
   const htmlObject = document.createElement("div");
   htmlObject.innerHTML = htmlString;
 
-  //cleanup
-  for (const pElem of htmlObject.getElementsByTagName("p")) {
+  for (const pElem of Array.from(htmlObject.querySelectorAll("p"))) {
     pElem.removeAttribute("dir");
   }
 


### PR DESCRIPTION
## Basic information

* Tiller version: 1.8.0
* Module: form-elements-advanced

## Description
Changed `htmlObject.getElementsByTagName("p")` to `Array.from(htmlObject.querySelectorAll("p"))` because the return of the `getElementsByTagName()` function is not iterable, which causes `semantic error TS2569: Type 'HTMLCollectionOf<HTMLParagraphElement>' is not an array type or a string type.`

### Related issue

Closes #204 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
