### PR TITLE
#201 Add onClick prop and functionality to DataTable

### DIFF
--- a/libs/data-display/src/DataTable.tsx
+++ b/libs/data-display/src/DataTable.tsx
@@ -682,10 +682,15 @@ function DataTable<T extends object>({
                         )}
                       >
                         {primaryCells.map((cell, cellKey) => {
+                          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                           // @ts-ignore
                           const colSpan = cell.column.colSpan;
+                          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                           // @ts-ignore
                           const align = cell.column.align;
+                          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                          // @ts-ignore
+                          const isSelector = cell.column.id === "selector";
                           return (
                             <td
                               key={cellKey}
@@ -698,8 +703,10 @@ function DataTable<T extends object>({
                               )}
                               {...cell.getCellProps()}
                               colSpan={colSpan}
-                              onClick={() => (onClick ? onClick(row.original) : undefined)}
-                              onDoubleClick={() => (onDoubleClick ? onDoubleClick(row.original) : undefined)}
+                              onClick={() => (onClick && !isSelector ? onClick(row.original) : undefined)}
+                              onDoubleClick={() =>
+                                onDoubleClick && !isSelector ? onDoubleClick(row.original) : undefined
+                              }
                             >
                               {cell.render("Cell")}
                             </td>

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -482,10 +482,21 @@ export const WithClickableRows = () => {
       >
         <DataTable.Column header="ID" accessor="id" />
         <DataTable.Column header="Name" accessor="name" />
+        <DataTable.Column header="Edit" id="edit" canClick={false} className="w-12">
+          {(item: Item) => (
+            <div className="flex justify-start items-center space-x-1 z-50">
+              <IconButton icon={<Icon type="pencil-simple" variant="fill" className="text-gray-500" />} label="Edit" />
+              <IconButton icon={<Icon type="trash" variant="fill" className="text-gray-500" />} label="Delete" />
+            </div>
+          )}
+        </DataTable.Column>
       </DataTable>
-      <Typography>
-        Clicked: <b>{selectedRow?.name || "-"}</b>
-      </Typography>
+      <div className="flex w-full justify-between">
+        <Typography>
+          Clicked: <b>{selectedRow?.name || "-"}</b>
+        </Typography>
+        <Typography>*clicking on the actions column is disabled</Typography>
+      </div>
     </>
   );
 };

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -482,21 +482,26 @@ export const WithClickableRows = () => {
       >
         <DataTable.Column header="ID" accessor="id" />
         <DataTable.Column header="Name" accessor="name" />
-        <DataTable.Column header="Edit" id="edit" canClick={false} className="w-12">
+        <DataTable.Column header="Edit" id="edit" className="w-12">
           {(item: Item) => (
             <div className="flex justify-start items-center space-x-1 z-50">
-              <IconButton icon={<Icon type="pencil-simple" variant="fill" className="text-gray-500" />} label="Edit" />
-              <IconButton icon={<Icon type="trash" variant="fill" className="text-gray-500" />} label="Delete" />
+              <IconButton
+                icon={<Icon type="pencil-simple" variant="fill" className="text-gray-500" />}
+                label="Edit"
+                onClick={(e) => e.stopPropagation()}
+              />
+              <IconButton
+                icon={<Icon type="trash" variant="fill" className="text-gray-500" />}
+                label="Delete"
+                onClick={(e) => e.stopPropagation()}
+              />
             </div>
           )}
         </DataTable.Column>
       </DataTable>
-      <div className="flex w-full justify-between">
-        <Typography>
-          Clicked: <b>{selectedRow?.name || "-"}</b>
-        </Typography>
-        <Typography>*clicking on the actions column is disabled</Typography>
-      </div>
+      <Typography>
+        Clicked: <b>{selectedRow?.name || "-"}</b>
+      </Typography>
     </>
   );
 };
@@ -566,6 +571,22 @@ export const WithDoubleClickableRows = () => {
       >
         <DataTable.Column header="ID" accessor="id" />
         <DataTable.Column header="Name" accessor="name" />
+        <DataTable.Column header="Edit" id="edit" className="w-12">
+          {(item: Item) => (
+            <div className="flex justify-start items-center space-x-1 z-50">
+              <IconButton
+                icon={<Icon type="pencil-simple" variant="fill" className="text-gray-500" />}
+                label="Edit"
+                onDoubleClick={(e) => e.stopPropagation()}
+              />
+              <IconButton
+                icon={<Icon type="trash" variant="fill" className="text-gray-500" />}
+                label="Delete"
+                onDoubleClick={(e) => e.stopPropagation()}
+              />
+            </div>
+          )}
+        </DataTable.Column>
       </DataTable>
       <Typography>
         Double-clicked: <b>{selectedRow?.name || "-"}</b>

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -16,6 +16,7 @@
  */
 
 import * as React from "react";
+import { useState } from "react";
 
 import { range, slice } from "lodash";
 
@@ -416,12 +417,151 @@ export const WithFooterUsingLocalSummary = () => {
   );
 };
 
-export const WithClickableRows = (args) => (
-  <DataTable data={smallData} onDoubleClick={() => {}}>
-    <DataTable.Column header="ID" accessor="id" />
-    <DataTable.Column header="Name" accessor="name" />
-  </DataTable>
-);
+export const WithClickableRows = () => {
+  // incl-code
+  const [selectedRow, setSelectedRow] = useState<Item>();
+
+  return (
+    <>
+      <DataTable
+        data={[
+          {
+            id: 1,
+            name: "Emily",
+            surname: "Moore",
+            age: 12,
+            appliedFor: "Nurse",
+            jobDescription:
+              "You will be tasked with caring for pediatric patients with a variety of health conditions and challenges as well as collaborating with physicians to provide the highest-quality care possible to each individual. As a registered nurse on staff, you will communicate orders to medical assistants and other team members and coordinate with staff and families to ensure the adherence to the attending physician’s instructions as well as proper care and disease control practices.",
+            salary: {
+              annual: 60000,
+              bonus: 1000,
+            },
+          },
+          {
+            id: 2,
+            name: "Michael",
+            surname: "Williams",
+            age: 25,
+            appliedFor: "Teacher",
+            jobDescription:
+              "The teaching profession is exciting and challenging. Teachers act as role models, mentors, caregivers and advisers. They can have a profound effect on the lives of their students.",
+            salary: {
+              annual: 72000,
+              bonus: 1200,
+            },
+          },
+          {
+            id: 3,
+            name: "Sarah",
+            surname: "Brown",
+            age: 38,
+            appliedFor: "Software developer",
+            jobDescription:
+              "The job of a software developer depends on the needs of the company, organization or team they are on. Some build and maintain systems that run devices and networks. Others develop applications that make it possible for people to perform specific tasks on computers, cellphones or other devices.",
+            salary: {
+              annual: 84000,
+              bonus: 1400,
+            },
+          },
+          {
+            id: 4,
+            name: "Matthew",
+            surname: "Davis",
+            age: 1,
+            appliedFor: "Lawyer",
+            jobDescription:
+              "A lawyer provides counsel and represents businesses, individuals, and government agencies in legal matters and disputes. A lawyer'ss main duties are to uphold the law while protecting a client's rights. Lawyers advise, research, and collect evidence or information, draft legal documents such as contracts, divorces, or real estate transactions, and defend or prosecute in court",
+            salary: {
+              annual: 96000,
+              bonus: 1600,
+            },
+          },
+        ]}
+        onClick={setSelectedRow}
+      >
+        <DataTable.Column header="ID" accessor="id" />
+        <DataTable.Column header="Name" accessor="name" />
+      </DataTable>
+      <Typography>
+        Clicked: <b>{selectedRow?.name || "-"}</b>
+      </Typography>
+    </>
+  );
+};
+
+export const WithDoubleClickableRows = () => {
+  // incl-code
+  const [selectedRow, setSelectedRow] = useState<Item>();
+
+  return (
+    <>
+      <DataTable
+        data={[
+          {
+            id: 1,
+            name: "Emily",
+            surname: "Moore",
+            age: 12,
+            appliedFor: "Nurse",
+            jobDescription:
+              "You will be tasked with caring for pediatric patients with a variety of health conditions and challenges as well as collaborating with physicians to provide the highest-quality care possible to each individual. As a registered nurse on staff, you will communicate orders to medical assistants and other team members and coordinate with staff and families to ensure the adherence to the attending physician’s instructions as well as proper care and disease control practices.",
+            salary: {
+              annual: 60000,
+              bonus: 1000,
+            },
+          },
+          {
+            id: 2,
+            name: "Michael",
+            surname: "Williams",
+            age: 25,
+            appliedFor: "Teacher",
+            jobDescription:
+              "The teaching profession is exciting and challenging. Teachers act as role models, mentors, caregivers and advisers. They can have a profound effect on the lives of their students.",
+            salary: {
+              annual: 72000,
+              bonus: 1200,
+            },
+          },
+          {
+            id: 3,
+            name: "Sarah",
+            surname: "Brown",
+            age: 38,
+            appliedFor: "Software developer",
+            jobDescription:
+              "The job of a software developer depends on the needs of the company, organization or team they are on. Some build and maintain systems that run devices and networks. Others develop applications that make it possible for people to perform specific tasks on computers, cellphones or other devices.",
+            salary: {
+              annual: 84000,
+              bonus: 1400,
+            },
+          },
+          {
+            id: 4,
+            name: "Matthew",
+            surname: "Davis",
+            age: 1,
+            appliedFor: "Lawyer",
+            jobDescription:
+              "A lawyer provides counsel and represents businesses, individuals, and government agencies in legal matters and disputes. A lawyer'ss main duties are to uphold the law while protecting a client's rights. Lawyers advise, research, and collect evidence or information, draft legal documents such as contracts, divorces, or real estate transactions, and defend or prosecute in court",
+            salary: {
+              annual: 96000,
+              bonus: 1600,
+            },
+          },
+        ]}
+        onDoubleClick={setSelectedRow}
+      >
+        <DataTable.Column header="ID" accessor="id" />
+        <DataTable.Column header="Name" accessor="name" />
+      </DataTable>
+      <Typography>
+        Double-clicked: <b>{selectedRow?.name || "-"}</b>
+      </Typography>
+    </>
+  );
+};
 
 export const WithoutHeader = (args) => (
   <DataTable data={smallData} showHeader={false}>
@@ -1263,7 +1403,7 @@ export const WithDefaultAscendingSortUsingHook = () => {
       <DataTable.Column header="Name" accessor="name" canSort={true} />
       <DataTable.Column header="Surname" accessor="surname" canSort={true} />
     </DataTable>
-  )
+  );
 };
 
 export const WithDefaultAscendingMultiSort = () => {
@@ -1302,17 +1442,17 @@ export const WithDefaultAscendingMultiSort = () => {
         }
 
         return result;
-      }, 0)
+      }, 0),
     );
   }, [dataTableState.sortBy]);
 
   return (
     <DataTable data={sortedData} hook={dataTableHook} defaultSortBy={dataTableState.sortBy} multiSort>
-      <DataTable.Column header="ID" accessor="id" canSort={false}/>
-      <DataTable.Column header="Name" accessor="name" canSort={true}/>
-      <DataTable.Column header="Surname" accessor="surname" canSort={true}/>
+      <DataTable.Column header="ID" accessor="id" canSort={false} />
+      <DataTable.Column header="Name" accessor="name" canSort={true} />
+      <DataTable.Column header="Surname" accessor="surname" canSort={true} />
     </DataTable>
-  )
+  );
 };
 
 export const WithIconButtons = (args) => (
@@ -1504,6 +1644,7 @@ WithEmptyState.argTypes = HideControls;
 WithFooter.argTypes = HideControls;
 WithFooterUsingLocalSummary.argTypes = HideControls;
 WithClickableRows.argTypes = HideControls;
+WithDoubleClickableRows.argTypes = HideControls;
 WithoutHeader.argTypes = HideControls;
 WithExpanderAtBeginning.argTypes = HideControls;
 WithExpanderAtEnd.argTypes = HideControls;


### PR DESCRIPTION
## Basic information

* Tiller version: 1.8.0
* Module: data-display

## Description
Added `onClick` prop to `DataTable` component which takes the clicked row value as a parameter (similar to `onDoubleClick` function).

Added a story to demonstrate newly added `onClick` functionality.

### Related issue

Closes #201 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
