### PR TITLE
#241 Fix bug when Breadcrumbs icon is rendered between non-rendered elements

### DIFF
--- a/libs/core/src/Breadcrumbs.tsx
+++ b/libs/core/src/Breadcrumbs.tsx
@@ -54,13 +54,13 @@ function Breadcrumbs({ children, icon, className, ...props }: BreadcrumbsProps) 
     tokens.container.borderRadius,
     tokens.container.padding,
     tokens.container.display,
-    tokens.container.spaceBetween
+    tokens.container.spaceBetween,
   );
 
   const childContainerClassName = cx(
     tokens.childContainer.display,
     tokens.childContainer.alignItems,
-    tokens.childContainer.spaceBetween
+    tokens.childContainer.spaceBetween,
   );
 
   const breadcrumbIcon = useIcon("breadcrumbs", icon, { className: tokens.iconColor });
@@ -68,14 +68,18 @@ function Breadcrumbs({ children, icon, className, ...props }: BreadcrumbsProps) 
   return (
     <nav className="flex">
       <ol className={containerClassName}>
-        {React.Children.map(children, (child, index) => (
-          <li key={index} className="flex">
-            <div className={childContainerClassName}>
-              {index > 0 && React.cloneElement(breadcrumbIcon)}
-              {child}
-            </div>
-          </li>
-        ))}
+        {React.Children.map(
+          children,
+          (child, index) =>
+            child && (
+              <li key={index} className="flex">
+                <div className={childContainerClassName}>
+                  {index > 0 && React.cloneElement(breadcrumbIcon)}
+                  {child}
+                </div>
+              </li>
+            ),
+        )}
       </ol>
     </nav>
   );
@@ -91,7 +95,7 @@ function Breadcrumb({ children, ...props }: BreadcrumbProps) {
     tokens.breadcrumb.color,
     tokens.breadcrumb.hover,
     tokens.breadcrumb.transitionDuration,
-    tokens.breadcrumb.transitionTimingFunction
+    tokens.breadcrumb.transitionTimingFunction,
   );
 
   return <span className={breadcrumbClassname}>{children}</span>;


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version:
  1.12.0
* Module:
  core

## Additional information

<!-- Please, include any additional information that could be relevant (e.g. npm/yarn, OS version). -->

## Description

### Summary

Fixed a bug when icon is rendered between non-rendered elements of Breadcrumbs component.

### Details

Added check if child is undefined before rendering breadcrumb icon and breadcrumb child.

### Related issue

https://github.com/croz-ltd/tiller/issues/241

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
