### PR TITLE
#253 Add name-based id generation for Autocomplete and Select

### DIFF
--- a/libs/core/src/Badge.tsx
+++ b/libs/core/src/Badge.tsx
@@ -62,7 +62,15 @@ export type BadgeProps = {
   small?: boolean;
 
   /**
-   * Special attribute for enabling test automation support.
+   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
    */
   testId?: string;
 
@@ -92,7 +100,6 @@ export type BadgeRemoveButtonProps = {
 
 export default function Badge({
   children,
-  testId,
   color = "primary",
   small,
   dot,
@@ -112,11 +119,11 @@ export default function Badge({
     { [tokens.small.lineHeight]: small },
     tokens.master,
     tokens.variant[variant].base,
-    tokens.variant[variant].color[color].base
+    tokens.variant[variant].color[color].base,
   );
 
   return (
-    <span className={containerClassName} data-testid={testId} onClick={onClick}>
+    <span className={containerClassName} data-testid={props.testId} onClick={onClick}>
       {dot && <BadgeDot color={color} variant={variant} />}
       {children}
       {onRemoveButtonClick && (
@@ -125,7 +132,7 @@ export default function Badge({
           small={small}
           variant={variant}
           onClick={onRemoveButtonClick}
-          testId={testId}
+          testId={props.testId}
         />
       )}
     </span>

--- a/libs/core/src/Button.tsx
+++ b/libs/core/src/Button.tsx
@@ -70,6 +70,19 @@ export type ButtonProps = {
   size?: ButtonSize;
 
   /**
+   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  testId?: string;
+
+  /**
    * Icon on the right side of the button text.
    */
   trailingIcon?: React.ReactNode;
@@ -116,14 +129,21 @@ export default function Button({
     { [tokens.variant[variant].color[color].borderColor]: !isEqual(props.tokens, {}) },
     { [tokens.variant[variant].color[color].hover]: !isEqual(props.tokens, {}) && !disabled },
     { [tokens.variant[variant].color[color].shadow]: !isEqual(props.tokens, {}) },
-    className
+    className,
   );
 
   const leadingIconClassName = cx(tokens.leadingIcon[size], "flex justify-center items-center");
   const trailingIconClassName = cx(tokens.trailingIcon[size], "flex justify-center items-center");
 
   return (
-    <button ref={buttonRef} className={buttonClassName} id={id} data-testid={id} disabled={disabled} {...props}>
+    <button
+      ref={buttonRef}
+      className={buttonClassName}
+      id={id}
+      data-testid={props.testId || id}
+      disabled={disabled}
+      {...props}
+    >
       {leadingIcon && React.cloneElement(leadingIcon as React.ReactElement, { className: leadingIconClassName })}
       {children}
       {trailingIcon &&

--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -119,6 +119,19 @@ export type InputProps = {
   required?: boolean;
 
   /**
+   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  testId?: string;
+
+  /**
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
    */
   tooltip?: React.ReactNode;
@@ -271,7 +284,7 @@ const Input = React.forwardRef(
             ref={inputRef || ref}
             name={name}
             id={id}
-            data-testid={id}
+            data-testid={props.testId || id}
             disabled={disabled}
             className={inputClassName}
             {...props}

--- a/libs/form-elements/src/NumberInput.tsx
+++ b/libs/form-elements/src/NumberInput.tsx
@@ -93,6 +93,19 @@ export type NumberInputProps = {
   required?: boolean;
 
   /**
+   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  testId?: string;
+
+  /**
    * Custom thousand separator (e.g. "." or ",").
    *
    * If not provided, it will be inferred from the IntlProvider.
@@ -156,7 +169,7 @@ export default function NumberInput({
   return (
     <ReactNumberFormat
       id={id}
-      data-testid={id}
+      data-testid={props.testId || id}
       name={name}
       decimalSeparator={finalDecimalSeparator}
       thousandSeparator={finalThousandSeparator}

--- a/libs/form-elements/src/Textarea.tsx
+++ b/libs/form-elements/src/Textarea.tsx
@@ -69,6 +69,19 @@ export type TextareaProps = {
   textareaClassName?: string;
 
   /**
+   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  testId?: string;
+
+  /**
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
    */
   tooltip?: React.ReactNode;
@@ -113,7 +126,7 @@ export default function Textarea({
     { [tokens.error.color]: error },
     { [tokens.error.placeholder]: error },
     { [tokens.error.boxShadow]: error },
-    { [tokens.disabled]: disabled }
+    { [tokens.disabled]: disabled },
   );
 
   const inputContainerClassName = cx("relative", tokens.container.base, { [tokens.container.withLabel]: label });
@@ -134,7 +147,7 @@ export default function Textarea({
       <textarea
         name={name}
         id={id}
-        data-testid={id}
+        data-testid={props.testId || id}
         value={value}
         className={textareaComponentClassName}
         disabled={disabled}

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -963,6 +963,7 @@ function Autocomplete<T extends {}>({
         extend={tags && tagsContained && tagsDisplay}
         addonBelow={tags && !tagsContained && tagsDisplay}
         {...getInputProps({
+          id: id,
           ref: !tagsContained ? toggleRef : inputRef,
           refKey: "inputRef",
           value: highlightedOption && !allowMultiple ? safeItemToString(highlightedOption) : inputValue,

--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -221,6 +221,20 @@ export type AutocompleteProps<T extends {}> = {
    * sort = {(items: Item[]) => items.sort((a, b) => a.name.localeCompare(b.name))}
    */
   sort?: (items: T[]) => T[];
+
+  /**
+   * A unique identifier for testing purposes, equivalent to the 'data-testid' attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  testId?: string;
+
   /**
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
    */
@@ -930,6 +944,7 @@ function Autocomplete<T extends {}>({
       <Input
         className={className}
         id={id}
+        testId={props.testId || id}
         label={label}
         tooltip={tooltip}
         help={help}

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -395,7 +395,13 @@ function Select<T>({
       <div className={tokens.container} ref={containerRef}>
         <button
           className={selectClassName}
-          {...getToggleButtonProps({ ref: toggleRef, disabled: isDisabled, onClick: () => setIsMenuOpen(!isMenuOpen) })}
+          {...getToggleButtonProps({
+            id: id,
+            ref: toggleRef,
+            disabled: isDisabled,
+            onClick: () => setIsMenuOpen(!isMenuOpen),
+          })}
+          data-testid={id}
           type="button"
           style={{
             backgroundImage:
@@ -434,7 +440,7 @@ function Select<T>({
             {isOpen && (
               <div className={listClassName}>
                 <div className={listInnerClassName}>
-                  <div className={tokens.Items.container}>
+                  <div className={tokens.Items.container} {...getMenuProps({ ref: inputRef })}>
                     <SelectItems />
                   </div>
                 </div>

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -440,7 +440,7 @@ function Select<T>({
             {isOpen && (
               <div className={listClassName}>
                 <div className={listInnerClassName}>
-                  <div className={tokens.Items.container} {...getMenuProps({ ref: inputRef })}>
+                  <div className={tokens.Items.container}>
                     <SelectItems />
                   </div>
                 </div>

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -134,6 +134,19 @@ export type SelectProps<T> = {
   sort?: (items: T[]) => T[];
 
   /**
+   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent testId="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  testId?: string;
+
+  /**
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
    */
   tooltip?: React.ReactNode;
@@ -401,7 +414,7 @@ function Select<T>({
             disabled: isDisabled,
             onClick: () => setIsMenuOpen(!isMenuOpen),
           })}
-          data-testid={id}
+          data-testid={props.testId || id}
           type="button"
           style={{
             backgroundImage:


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version:
  1.13.0
* Module: selectors

## Description

### Summary

Added name based id generation on `Autocomplete` and `Select` components by assigning the value of `input-${name}` to the respective `id` props.

### Related issue

https://github.com/croz-ltd/tiller/issues/253

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
