### PR TITLE
#254 Fix date picker current date's conflicting text class names

### DIFF
--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -739,7 +739,7 @@ const defaultComponentConfig = {
         firstOrLast: "bg-primary text-primary-contrast",
         selected: "bg-primary-light text-primary-contrast",
         hovered: "bg-primary-light text-primary-contrast",
-        currentDate: "ring-2 ring-inset ring-white border border-primary-dark text-primary-dark",
+        currentDate: "ring-2 ring-inset ring-white border border-primary-dark",
         dateHovered: `hover:bg-primary hover:text-primary-contrast`,
         yearHovered: `hover:bg-primary hover:text-primary-contrast`,
         disabled: "opacity-50 text-slate-700 ",
@@ -1621,11 +1621,11 @@ const defaultComponentConfig = {
     contentContainer: "px-4 py-8 sm:px-0 z-0",
     navigationContainer: {
       fixed: "transition duration-300 w-full sticky top-0 z-30",
-      scrolled: "-translate-y-full"
+      scrolled: "-translate-y-full",
     },
     heading: {
       fixed: "bg-gray-100 transition duration-300 sticky top-0 w-full z-20",
-    }
+    },
   },
   StatusButton: {
     icon: {


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.13.0
* Module: theme

## Description

### Summary

Fixed conflicting class names applied to the current date in date picker (rendered for every date input component) if `highlightToday` prop is enabled and current date is selected.

### Details

When enabling `highlightToday` prop, the look of the highlighted day is strange, with conflicting class names applied at the same time: `text-primary-contrast` and `text-primary-dark`. This causes the date to have the dark class name applied sometimes (depending on which class name is compiled first), resulting in a visually unappealing result.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#254 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
