### PR TITLE
#251 Fix DropdownMenu not registering icon props properly

### DIFF
--- a/libs/menu/src/DropdownMenu.tsx
+++ b/libs/menu/src/DropdownMenu.tsx
@@ -131,9 +131,19 @@ function DropdownMenu({
     { [tokens.Icon.color.light]: iconColor === "light" },
   );
 
-  const iconProps = { className: iconClassName, size: 3 };
-  const finalOpenExpanderIcon = useIcon("openExpander", openExpanderIcon, iconProps);
-  const finalCloseExpanderIcon = useIcon("closeExpander", closeExpanderIcon, iconProps);
+  const openIconProps = {
+    className: openExpanderIcon?.props.className || iconClassName,
+    size: openExpanderIcon?.props.size || 3,
+    ...openExpanderIcon?.props,
+  };
+  const finalOpenExpanderIcon = useIcon("openExpander", openExpanderIcon, openIconProps);
+
+  const closeIconProps = {
+    className: closeExpanderIcon?.props.className || iconClassName,
+    size: closeExpanderIcon?.props.size || 3,
+    ...closeExpanderIcon?.props,
+  };
+  const finalCloseExpanderIcon = useIcon("closeExpander", closeExpanderIcon, closeIconProps);
 
   const responsiveIcon = (
     <div>


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.13.0
* Module: menu

## Description

### Summary

Fixed logic for registering styling for `DropdownMenu`'s `openExpanderIcon` and `closeExpanderIcon` props by prioritizing defined props directly from the `<Icon .../>` component over defaults.

### Details

Logic for styling icons follows this flow:  
 - if `open/closeExpanderIcon` is defined without any props, defaults are set 
 - if `open/closeExpanderIcon` is defined with some props, those props override defaults, while other props resort to defined defaults

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#251 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
