### PR TITLE
#236 DataTable - add `retainDefaultSortBy` prop for preserving default sorting

### DIFF
--- a/libs/data-display/src/useSortableDataTable.tsx
+++ b/libs/data-display/src/useSortableDataTable.tsx
@@ -1,9 +1,14 @@
 import { useMemo } from "react";
 
 import { useDataTable } from "./index";
+import { SortInfo } from "./DataTable";
 
-export default function useSortableDataTable<T, U extends keyof T>(initialData: T[], columnMapping: Record<U, string>) {
-  const [dataTableState, dataTableHook] = useDataTable();
+export default function useSortableDataTable<T, U extends keyof T>(
+  initialData: T[],
+  columnMapping: Record<U, string>,
+  defaultSortBy?: SortInfo[],
+) {
+  const [dataTableState, dataTableHook] = useDataTable({ defaultSortBy });
 
   const generateSortedData = useMemo(() => {
     const sortInstructions = dataTableState.sortBy;
@@ -15,7 +20,7 @@ export default function useSortableDataTable<T, U extends keyof T>(initialData: 
     return [...initialData].sort((a, b) => {
       for (const sortInfo of sortInstructions) {
         const columnKey = columnMapping[sortInfo.column];
-        const compareResult = sortInfo.sortDirection === "ASCENDING" ? -1 : 1;
+        const compareResult = sortInfo.sortDirection === "ASCENDING" ? 1 : -1;
         const aValue = a[columnKey];
         const bValue = b[columnKey];
 

--- a/storybook/src/data-display/DataTable.stories.tsx
+++ b/storybook/src/data-display/DataTable.stories.tsx
@@ -23,7 +23,7 @@ import { range, slice } from "lodash";
 import { withDesign } from "storybook-addon-designs";
 
 import { Button, Card, IconButton, Link, Pagination, Typography, useLocalPagination } from "@tiller-ds/core";
-import { DataTable, useDataTable, useLocalSummary, useSortableDataTable } from "@tiller-ds/data-display";
+import { DataTable, SortInfo, useDataTable, useLocalSummary, useSortableDataTable } from "@tiller-ds/data-display";
 import { Icon } from "@tiller-ds/icons";
 import { DropdownMenu } from "@tiller-ds/menu";
 import { defaultThemeConfig } from "@tiller-ds/theme";
@@ -1432,6 +1432,7 @@ export const WithDefaultAscendingSortByName = (args) => {
     <DataTable data={sortedData} hook={dataTableHook} defaultSortBy={dataTableState.sortBy}>
       <DataTable.Column header="ID" accessor="id" canSort={false} />
       <DataTable.Column header="Name" accessor="name" canSort={true} />
+      <DataTable.Column header="Surname" accessor="surname" canSort={true} />
     </DataTable>
   );
 };
@@ -1443,26 +1444,63 @@ export const WithDefaultAscendingSortUsingHook = () => {
     surname: "surname",
   };
 
-  const { dataTableHook, sortedData } = useSortableDataTable(allData || [], columnMapping);
+  const defaultSortBy: SortInfo[] = [
+    {
+      column: "name",
+      sortDirection: "DESCENDING",
+    },
+    {
+      column: "surname",
+      sortDirection: "DESCENDING",
+    },
+  ];
+
+  const { dataTableHook, sortedData, dataTableState } = useSortableDataTable(
+    allData || [],
+    columnMapping,
+    defaultSortBy,
+  );
+
+  return (
+    <DataTable data={sortedData} hook={dataTableHook} defaultSortBy={dataTableState.sortBy}>
+      <DataTable.Column header="ID" accessor="id" canSort={false} />
+      <DataTable.Column header="Name" accessor="name" canSort={true} />
+      <DataTable.Column header="Surname" accessor="surname" canSort={true} />
+    </DataTable>
+  );
+};
+
+export const WithDefaultAscendingSortWithRetainedInitialSort = () => {
+  // incl-code
+  const columnMapping = {
+    name: "name",
+    surname: "surname",
+  };
+
+  const defaultSortBy: SortInfo[] = [
+    {
+      column: "name",
+      sortDirection: "DESCENDING",
+    },
+  ];
+
+  const { dataTableHook, sortedData, dataTableState } = useSortableDataTable(
+    allData || [],
+    columnMapping,
+    defaultSortBy,
+  );
 
   return (
     <DataTable
       data={sortedData}
       hook={dataTableHook}
-      defaultSortBy={[
-        {
-          column: "name",
-          sortDirection: "ASCENDING",
-        },
-        {
-          column: "surname",
-          sortDirection: "ASCENDING",
-        },
-      ]}
+      defaultSortBy={dataTableState.defaultSortBy}
+      retainDefaultSortBy={true}
     >
       <DataTable.Column header="ID" accessor="id" canSort={false} />
       <DataTable.Column header="Name" accessor="name" canSort={true} />
       <DataTable.Column header="Surname" accessor="surname" canSort={true} />
+      <DataTable.Column header="Applied for" accessor="appliedFor" canSort={true} />
     </DataTable>
   );
 };


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.13.0
* Module: data-display

## Description

### Summary

Added possibility of retaining initial sort defined by `defaultSortBy` prop when sorting `DataTable`'s columns via header arrows.

### Details

New prop has been added for retaining initial sort configuration:
 - `retainDefaultSortBy`

### Related issue

#236 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
