### PR TITLE
#250 Fix `Select` downshift console errors

### DIFF
--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -393,6 +393,7 @@ function Select<T>({
       containerClassName={className}
     >
       <div className={tokens.container} ref={containerRef}>
+        <div className="w-12 h-12 bg-primary" />
         <button
           className={selectClassName}
           {...getToggleButtonProps({ ref: toggleRef, disabled: isDisabled, onClick: () => setIsMenuOpen(!isMenuOpen) })}
@@ -424,24 +425,22 @@ function Select<T>({
             </div>
           </div>
         </button>
-        {hasOptions && (
-          <Popover
-            className="z-50"
-            targetRef={toggleRef}
-            position={positionMatchWidth}
-            {...getMenuProps({ ref: inputRef }, { suppressRefError: true })}
-          >
-            {isOpen && (
-              <div className={listClassName}>
-                <div className={listInnerClassName}>
-                  <div className={tokens.Items.container}>
-                    <SelectItems />
-                  </div>
+        <Popover
+          className="z-50"
+          targetRef={toggleRef}
+          position={positionMatchWidth}
+          {...getMenuProps({ ref: inputRef }, { suppressRefError: true })}
+        >
+          {isOpen && hasOptions && (
+            <div className={listClassName}>
+              <div className={listInnerClassName}>
+                <div className={tokens.Items.container}>
+                  <SelectItems />
                 </div>
               </div>
-            )}
-          </Popover>
-        )}
+            </div>
+          )}
+        </Popover>
       </div>
     </Field>
   );


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.13.0
* Module: selectors

## Description

### Summary

Fixed downshift errors appearing in the console when rendering `Select`/`SelectField` components by always (not conditionally) rendering the component using downshift's `getMenuProps` getter function.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#254 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
