### PR TITLE
#266 Fix DataTable crashing if number of children in a row is 1

### DIFF
--- a/libs/data-display/src/DataTable.tsx
+++ b/libs/data-display/src/DataTable.tsx
@@ -25,7 +25,10 @@ import {
   Row,
   SortingRule,
   useExpanded,
-   useRowSelect, useSortBy, useTable } from "react-table";
+  useRowSelect,
+  useSortBy,
+  useTable,
+} from "react-table";
 
 import { Card, CardHeaderProps } from "@tiller-ds/core";
 import { Checkbox } from "@tiller-ds/form-elements";
@@ -549,6 +552,10 @@ function DataTable<T extends object>({
   const secondaryColumnChildrenArray = React.Children.toArray(secondaryColumnChildren).filter(Boolean);
 
   function mapChildren(children: DataTableChild<T>[]) {
+    if (!Array.isArray(children)) {
+      return children;
+    }
+
     return children.map((child) => {
       if (!child) {
         return undefined;

--- a/storybook/src/base-documentation/ReleaseNotes.stories.mdx
+++ b/storybook/src/base-documentation/ReleaseNotes.stories.mdx
@@ -18,7 +18,13 @@ import { Meta } from "@storybook/addon-docs";
 
 # 📝 Release Notes
 
-## **1.14.0 - latest** <span>_(June 5th 2024)_</span>
+## **1.14.1 - latest** <span>_(June 17th 2024)_</span>
+
+**<h4>🐛 Bug Fixes</h4>**
+
+- Fixed `DataTable` crashing if rendered with one child in a row ([#266](https://github.com/croz-ltd/tiller/issues/266))
+
+## **1.14.0** <span>_(June 5th 2024)_</span>
 
 **<h4>🐛 Bug Fixes</h4>**
 


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.14.0
* Module: data-display

## Description

### Summary

Fixed `children.map` error appearing when rendering the `DataTable` component with only one column present in a row.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#266 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
