### PR TITLE
#268 Fix `DataTable` primary/secondary row rendering loop

### DIFF
--- a/libs/data-display/src/DataTable.tsx
+++ b/libs/data-display/src/DataTable.tsx
@@ -38,6 +38,7 @@ import { createNamedContext, findChild } from "@tiller-ds/util";
 type DataTableChild<T extends object> =
   | React.ReactElement<DataTableColumnProps<T> | DataTableExpanderProps<T>>
   | React.ReactElement<DataTableColumnProps<T> | DataTableExpanderProps<T>>[]
+  | boolean
   | undefined;
 
 export type DataTableProps<T extends object> = {
@@ -538,39 +539,12 @@ function DataTable<T extends object>({
   const secondaryRow = findChild("DataTableSecondaryRow", children);
   const hasSecondaryColumns = React.isValidElement(secondaryRow);
 
-  const primaryColumnChildren = React.useMemo(() => {
-    return mapChildren(React.isValidElement(primaryRow) ? primaryRow.props.children : children);
-  }, [primaryRow, children]);
-
+  const primaryColumnChildren = React.isValidElement(primaryRow) ? primaryRow.props.children : children;
   const primaryColumnChildrenArray = React.Children.toArray(primaryColumnChildren).filter(Boolean);
   const columnChildrenSize = primaryColumnChildrenArray.length;
 
-  const secondaryColumnChildren = React.useMemo(() => {
-    return React.isValidElement(secondaryRow) ? mapChildren(secondaryRow.props.children) : null;
-  }, [secondaryRow, children]);
-
+  const secondaryColumnChildren = React.isValidElement(secondaryRow) ? secondaryRow.props.children : null;
   const secondaryColumnChildrenArray = React.Children.toArray(secondaryColumnChildren).filter(Boolean);
-
-  function mapChildren(children: DataTableChild<T>[]) {
-    if (!Array.isArray(children)) {
-      return children;
-    }
-
-    return children.map((child) => {
-      if (!child) {
-        return undefined;
-      }
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      if (Array.isArray(child.props?.children)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return mapChildren(child.props?.children);
-      } else {
-        return child;
-      }
-    });
-  }
 
   const totalColumnChildrenSize = hasSecondaryColumns
     ? secondaryColumnChildrenArray.length + columnChildrenSize

--- a/storybook/src/base-documentation/ReleaseNotes.stories.mdx
+++ b/storybook/src/base-documentation/ReleaseNotes.stories.mdx
@@ -18,7 +18,13 @@ import { Meta } from "@storybook/addon-docs";
 
 # 📝 Release Notes
 
-## **1.14.1 - latest** <span>_(June 17th 2024)_</span>
+## **1.14.2 - latest** <span>_(June 17th 2024)_</span>
+
+**<h4>🐛 Bug Fixes</h4>**
+
+- Fixed `DataTable` crashing if rendered with primary/secondary rows ([#268](https://github.com/croz-ltd/tiller/issues/268))
+
+## 1.14.1 <span>_(June 17th 2024)_</span>
 
 **<h4>🐛 Bug Fixes</h4>**
 


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.14.1
* Module: data-display

## Description

### Summary

Fixed `maximum render depth` error appearing when rendering the `DataTable` component with primary/secondary columns.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#268

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
