### PR TITLE
#274 Fix `initialHtml` duplicated on `RichTextEditor` initial render

### DIFF
--- a/libs/form-elements-advanced/src/RichTextEditor.tsx
+++ b/libs/form-elements-advanced/src/RichTextEditor.tsx
@@ -690,20 +690,17 @@ type InitEditorProps = {
 
 function InitEditor({ initialHtml }: InitEditorProps) {
   const [editor] = useLexicalComposerContext();
-  const isEditorInitialized = useRef<boolean>(false);
 
   useEffect(() => {
-    if (initialHtml && !isEditorInitialized.current) {
+    initialHtml &&
       editor.update(() => {
         const parser = new DOMParser();
         const dom = parser.parseFromString(initialHtml, "text/html");
         const nodes = $generateNodesFromDOM(editor, dom);
         const root = $getRoot();
-        root.selectEnd();
+        root.clear();
         $insertNodes(nodes);
-        isEditorInitialized.current = true;
       });
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 

--- a/libs/form-elements-advanced/src/RichTextEditor.tsx
+++ b/libs/form-elements-advanced/src/RichTextEditor.tsx
@@ -690,9 +690,10 @@ type InitEditorProps = {
 
 function InitEditor({ initialHtml }: InitEditorProps) {
   const [editor] = useLexicalComposerContext();
+  const isEditorInitialized = useRef<boolean>(false);
 
   useEffect(() => {
-    initialHtml &&
+    if (initialHtml && !isEditorInitialized.current) {
       editor.update(() => {
         const parser = new DOMParser();
         const dom = parser.parseFromString(initialHtml, "text/html");
@@ -700,7 +701,9 @@ function InitEditor({ initialHtml }: InitEditorProps) {
         const root = $getRoot();
         root.selectEnd();
         $insertNodes(nodes);
+        isEditorInitialized.current = true;
       });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor]);
 


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.14.2
* Module: form-elements-advanced

## Description

### Summary

Fixed duplication of `initialHtml` prop when initially rendering `RichTextEditor` component with `React.StrictMode` enabled (on dev environments).

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#274 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
