### PR TITLE
#273 Fix visual inconsistencies between disabled input components

### DIFF
--- a/libs/selectors/src/Autocomplete.tsx
+++ b/libs/selectors/src/Autocomplete.tsx
@@ -627,6 +627,7 @@ function Autocomplete<T extends {}>({
   const selectClassName = cx(
     autocompleteTokens.Select.base,
     { [autocompleteTokens.Select.active]: !disabled },
+    { [autocompleteTokens.Select.disabled]: disabled },
     { "pt-2.5": tags && tagsContained && !value },
   );
 

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -125,6 +125,7 @@ const defaultComponentConfig = {
     Select: {
       base: "-m-2 pl-2 flex flex-col",
       active: "pointer-events-auto cursor-pointer hover:text-slate-700 ",
+      disabled: "opacity-50",
     },
     Separator: {
       container: "pl-2",
@@ -1013,7 +1014,7 @@ const defaultComponentConfig = {
       autocomplete: "py-2 pl-3 pr-20",
     },
     boxShadow: `focus-within:ring focus-within:outline-none focus-within:ring-primary-light`,
-    disabled: "opacity-50",
+    disabled: "opacity-50 bg-slate-100",
     addOn: {
       master: "flex-1 block",
       padding: "py-2 px-3",
@@ -1444,7 +1445,7 @@ const defaultComponentConfig = {
       fontSize: "sm:text-sm",
       lineHeight: "sm:leading-5",
       error: `border border-danger text-danger-dark placeholder-danger focus:ring focus:border-danger-300 focus:ring-danger-light`,
-      disabled: "opacity-50",
+      disabled: "opacity-50 bg-slate-100",
       input: "absolute w-0 h-0",
     },
     container: "relative w-full",
@@ -1701,7 +1702,7 @@ const defaultComponentConfig = {
         color: "text-danger",
       },
     },
-    disabled: "opacity-50",
+    disabled: "opacity-50 bg-slate-100",
   },
   TimePicker: {
     container: "w-full flex flex-col items-center justify-center bg-white shadow p-2 left-0",


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.14.2
* Module: form-elements

## Description

### Summary

Fixed visual inconsistencies between disabled input components by adding a joint class name `bg-slate-100` to input and select components for uniform disabled look.

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#273

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
