### PR TITLE
#277 Fix `RichTextEditor`'s list, table and link functionality unresponsiveness

### DIFF
--- a/libs/form-elements-advanced/src/RichTextEditor.tsx
+++ b/libs/form-elements-advanced/src/RichTextEditor.tsx
@@ -44,7 +44,7 @@ import {
   ListType,
 } from "@lexical/list";
 import { $isLinkNode, TOGGLE_LINK_COMMAND, LinkNode } from "@lexical/link";
-import { $wrapNodes, $isAtNodeEnd } from "@lexical/selection";
+import { $setBlocksType, $isAtNodeEnd } from "@lexical/selection";
 import { $createHeadingNode, HeadingNode, $isHeadingNode } from "@lexical/rich-text";
 import { INSERT_TABLE_COMMAND, TableNode, TableCellNode, TableRowNode } from "@lexical/table";
 
@@ -253,7 +253,7 @@ function RichTextEditorToolbar(): JSX.Element {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
         if (listType === "none") {
-          $wrapNodes(selection, () => $createParagraphNode());
+          $setBlocksType(selection, () => $createParagraphNode());
         }
       }
     });
@@ -264,7 +264,7 @@ function RichTextEditorToolbar(): JSX.Element {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
         if (listType === "bullet") {
-          $wrapNodes(selection, () => $createParagraphNode());
+          $setBlocksType(selection, () => $createParagraphNode());
         } else {
           editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined);
         }
@@ -277,7 +277,7 @@ function RichTextEditorToolbar(): JSX.Element {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
         if (listType === "number") {
-          $wrapNodes(selection, () => $createParagraphNode());
+          $setBlocksType(selection, () => $createParagraphNode());
         } else {
           editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined);
         }
@@ -356,7 +356,7 @@ function RichTextEditorToolbar(): JSX.Element {
                 if ($isRangeSelection(selection)) {
                   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                   // @ts-ignore
-                  $wrapNodes(selection, () => $createHeadingNode(`h${i + 1}`));
+                  $setBlocksType(selection, () => $createHeadingNode(`h${i + 1}`));
                 }
               });
             }}
@@ -519,6 +519,7 @@ function RichTextEditorToolbar(): JSX.Element {
               linkModal.onClose();
             }}
             color="danger"
+            variant="outlined"
             className="sm:mr-auto"
           >
             Remove link
@@ -588,8 +589,8 @@ export default function RichTextEditor({ initialHtml, onHtmlChange }: RichTextEd
       nested: {
         listitem: "list-none",
       },
-      ul: "list-disc list-inside pl-5",
-      ol: "list-decimal list-inside pl-5",
+      ul: `list-disc list-inside pl-5 ${generateParagraphStyles()}`,
+      ol: `list-decimal list-inside pl-5 ${generateParagraphStyles()}`,
     },
     text: {
       bold: "font-bold",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
   "dependencies": {
     "@datepicker-react/hooks": "2.3.1",
     "@lexical/react": "^0.11.0",
+    "@lexical/html": "^0.11.0",
+    "@lexical/list": "^0.11.0",
+    "@lexical/link": "^0.11.0",
+    "@lexical/selection": "^0.11.0",
+    "@lexical/rich-text": "^0.11.0",
+    "@lexical/table": "^0.11.0",
+    "@lexical/utils": "^0.11.0",
     "@reach/dialog": "^0.10.1",
     "@reach/menu-button": "^0.10.1",
     "@reach/popover": "^0.10.2",


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.14.2
* Module: form-elements-advanced

## Description

### Summary

Fixed `RichTextEditor`'s broken functionalities of buttons for following features:
 - ordered lists
 - unordered lists
 - table
 - link

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#277

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
