### PR TITLE
#283 Expand `Notification`'s customization capabilities

### DIFF
--- a/libs/alert/src/Notification.tsx
+++ b/libs/alert/src/Notification.tsx
@@ -165,9 +165,9 @@ export default function Notification({
   );
 
   const innerContainerClassName = cx(
-    tokens.Container.inner.base,
-    { [tokens.Container.inner.regular]: !condensed },
-    { [tokens.Container.inner.condensed]: condensed },
+    tokens.Container.outer.base,
+    { [tokens.Container.outer.regular]: !condensed },
+    { [tokens.Container.outer.condensed]: condensed },
   );
 
   const containerClassName = cx(

--- a/libs/alert/src/Notification.tsx
+++ b/libs/alert/src/Notification.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { ComponentTokens, cx, IconProps, useIcon, useTokens } from "@tiller-ds/theme";
 
-type NotificationColor = "info" | "danger" | "warning" | "success";
+type NotificationType = "info" | "danger" | "warning" | "success";
 
 export type NotificationProps = {
   /**
@@ -69,7 +69,7 @@ export type NotificationProps = {
   /**
    * Provides default styling sets for the notification with icon and color presets.
    */
-  type?: NotificationColor;
+  type?: NotificationType;
 
   /**
    * Disables the default background accent style provided by the `type` prop.

--- a/libs/alert/src/Notification.tsx
+++ b/libs/alert/src/Notification.tsx
@@ -17,7 +17,9 @@
 
 import * as React from "react";
 
-import { ComponentTokens, cx, useIcon, useTokens } from "@tiller-ds/theme";
+import { ComponentTokens, cx, IconProps, useIcon, useTokens } from "@tiller-ds/theme";
+
+type NotificationColor = "info" | "danger" | "warning" | "success";
 
 export type NotificationProps = {
   /**
@@ -45,13 +47,17 @@ export type NotificationProps = {
   content?: React.ReactNode;
 
   /**
-   * Optional icon located on the left side of the notification text title.
+   * An optional icon displayed on the left side of the notification text title.
+   *
+   * If provided, this will override the `type` property and its default icon mapping for `mainIcon`.
    */
   icon?: React.ReactNode;
 
   /**
-   * Function which, by default, closes the notification on click (if closeButton prop is enabled),
-   * An additional optional custom function can be defined here, to execute alongside the process of closing the notification.
+   * Callback function triggered when the notification is dismissed.
+   *
+   * By default, this function closes the notification when the `closeButton` prop is enabled.
+   * You can define a custom function here to execute additional logic alongside the default dismissal behavior.
    */
   onDismiss?: () => void;
 
@@ -61,10 +67,42 @@ export type NotificationProps = {
   title: React.ReactNode;
 
   /**
+   * Provides default styling sets for the notification with icon and color presets.
+   */
+  type?: NotificationColor;
+
+  /**
+   * Disables the default background accent style provided by the `type` prop.
+   *
+   * This has no effect if the `type` property is not specified.
+   */
+  disableAccent?: boolean;
+
+  /**
+   * Allows customization of the provided default styling (via `type` prop) for the main and dismiss icons.
+   *
+   * - `mainIcon`: Overrides styling for the primary icon, but is ignored if the `type` property is not defined.
+   * - `dismissIcon`: Overrides styling for the dismiss icon, but is ignored if the `type` property is not defined or if the `closeButton` prop is set to `true`.
+   *
+   * Accepts partial styling configurations.
+   */
+  iconProps?: {
+    mainIcon?: Partial<IconProps>;
+    dismissIcon?: Partial<IconProps>;
+  };
+
+  /**
    * If on, reduces the padding to give the component a more condensed feel.
    */
   condensed?: boolean;
 
+  /**
+   * Optional icon displayed on the right side of the notification title, used for closing the notification.
+   *
+   * - Overrides the default icon mapped by the `type` property for `dismissIcon` when provided.
+   * - Ignored if the `closeButton` prop is set to `true`.
+   *
+   */
   dismissIcon?: React.ReactElement;
 
   /**
@@ -88,6 +126,9 @@ export default function Notification({
   onDismiss,
   dismissIcon,
   className,
+  type,
+  disableAccent,
+  iconProps,
   ...props
 }: NotificationProps) {
   const tokens = useTokens("Notification", props.tokens);
@@ -102,7 +143,20 @@ export default function Notification({
 
   const dismissButtonClassName = cx(tokens.dismiss.Button.master, tokens.dismiss.Button.color);
 
-  const finalDismissIcon = useIcon("dismiss", dismissIcon);
+  const dismissIconProps: Partial<IconProps> = {
+    className: iconProps?.dismissIcon?.className,
+    size: iconProps?.dismissIcon?.size ?? 3,
+    variant: iconProps?.dismissIcon?.variant,
+  };
+
+  const mainIconProps: Partial<IconProps> = {
+    className: iconProps?.mainIcon?.className ?? tokens.icon.type[type ?? "info"],
+    size: iconProps?.mainIcon?.size ?? 6,
+    variant: iconProps?.mainIcon?.variant ?? "fill",
+  };
+
+  const finalDismissIcon = useIcon("dismiss", dismissIcon, dismissIconProps);
+  const finalMainIcon = useIcon(type ?? "info", icon as React.ReactElement, mainIconProps);
 
   const dismiss = (
     <button className={dismissButtonClassName} onClick={onDismiss}>
@@ -111,17 +165,19 @@ export default function Notification({
   );
 
   const innerContainerClassName = cx(
-    tokens.Container.outer.base,
-    { [tokens.Container.outer.regular]: !condensed },
-    { [tokens.Container.outer.condensed]: condensed }
+    tokens.Container.inner.base,
+    { [tokens.Container.inner.regular]: !condensed },
+    { [tokens.Container.inner.condensed]: condensed },
   );
 
   const containerClassName = cx(
     tokens.Container.master,
+    { [tokens.Container.backgroundColor[String(type)]]: type && !disableAccent },
+    { [tokens.Container.backgroundColor.default]: !type || disableAccent },
     tokens.Container.backgroundColor,
     tokens.Container.borderRadius,
     tokens.Container.boxShadow,
-    className
+    className,
   );
 
   const titleClassName = cx(tokens.title.color, tokens.title.fontSize, tokens.title.fontWeight);
@@ -133,8 +189,8 @@ export default function Notification({
   return (
     <section className={containerClassName}>
       <div className={innerContainerClassName}>
-        {icon && <div className="flex-shrink-0">{icon}</div>}
-        <div className="flex-1 ml-3">
+        {(icon || type) && <div className={tokens.icon.master}>{type ? finalMainIcon : icon}</div>}
+        <div className={tokens.Container.content}>
           <p className={titleClassName}>{title}</p>
           <div className={contentClassName}>{content}</div>
           {condensed && onDismiss && actions}
@@ -142,8 +198,8 @@ export default function Notification({
         </div>
         {closeButton && <div className={dismissClassName}>{dismiss}</div>}
         {!closeButton && (
-          <div className={`flex border-l pl-2 ${tokens.actions.borderColor}`}>
-            <div className="-ml-px flex flex-col">{actions}</div>
+          <div className={`${tokens.actions.noCloseButton.container} ${tokens.actions.borderColor}`}>
+            <div className={tokens.actions.noCloseButton.innerContainer}>{actions}</div>
           </div>
         )}
       </div>

--- a/libs/alert/src/NotificationProvider.tsx
+++ b/libs/alert/src/NotificationProvider.tsx
@@ -24,6 +24,7 @@ import { createNamedContext } from "@tiller-ds/util";
 import Notification from "./Notification";
 import NotificationContainer from "./NotificationContainer";
 import { NotificationPosition } from "./NotificationPositionType";
+import { InternalNotificationProps } from "./index";
 
 type NotificationProviderProps = {
   /**
@@ -45,47 +46,7 @@ type NotificationProviderProps = {
   children: React.ReactNode;
 };
 
-export type NotificationProps = {
-  /**
-   * An array containing the components to be displayed under the title and description.
-   * Most often buttons or hyperlinks.
-   */
-  actions?: React.ReactNode[];
-
-  /**
-   * Defines whether the clear button is shown on the component.
-   * Turned on by default.
-   */
-  closeButton?: boolean;
-
-  /**
-   * Optional description of the notification displayed under the title.
-   * Previously named "subtitle".
-   */
-  content?: React.ReactNode;
-
-  /**
-   * Custom timeout value, describing how long the notification stays on screen when rendered.
-   * Defaults to 3000 ms (3 seconds).
-   */
-  timeout?: number;
-
-  /**
-   * Optional icon located on the left side of the notification text title.
-   */
-  icon?: React.ReactElement;
-
-  /**
-   * Function which, by default, closes the notification on click (if closeButton prop is enabled),
-   * An additional optional custom function can be defined here, to execute alongside the process of closing the notification.
-   */
-  onDismiss?: () => void;
-
-  /**
-   * The title displayed accentuated above the optional description.
-   */
-  title: string | React.ReactElement;
-};
+export type NotificationProps = InternalNotificationProps;
 
 type NotificationContext = {
   notifications: NotificationProps[];
@@ -147,12 +108,8 @@ export default function NotificationProvider({
         {notifications.notifications.map((notification, key) => (
           <Notification
             key={key}
-            title={notification.title}
-            content={notification.content}
-            icon={notification.icon}
-            actions={notification.actions}
+            {...notification}
             timeout={notification.timeout || timeout}
-            closeButton={notification.closeButton}
             onDismiss={() => handleDismiss(notification)}
           />
         ))}

--- a/libs/icons/src/Icon.tsx
+++ b/libs/icons/src/Icon.tsx
@@ -17,13 +17,13 @@
 
 import * as React from "react";
 
-import { cx } from "@tiller-ds/theme";
+import { cx, IconVariant as ThemeIconVariant } from "@tiller-ds/theme";
 
 import iconTypes from "./iconTypes";
 
 export type IconType = typeof iconTypes[number] | undefined;
 
-export type IconVariant = "thin" | "light" | "regular" | "bold" | "fill";
+export type IconVariant = ThemeIconVariant;
 
 export type IconProps = {
   /**

--- a/libs/icons/src/iconConfig.tsx
+++ b/libs/icons/src/iconConfig.tsx
@@ -29,7 +29,6 @@ const iconConfig: IconConfig = {
   paginatorPrevious: (props: Partial<IconProps>) => <Icon type="caret-left" {...props} />,
   paginatorNext: (props: Partial<IconProps>) => <Icon type="caret-right" {...props} />,
   completed: (props: Partial<IconProps>) => <Icon type="check" variant="bold" {...props} />,
-  warning: (props: Partial<IconProps>) => <Icon type="warning" variant="fill" {...props} />,
   sortDesc: (props: Partial<IconProps>) => <Icon type="caret-down" variant="bold" {...props} />,
   sortAsc: (props: Partial<IconProps>) => <Icon type="caret-up" variant="bold" {...props} />,
   date: (props: Partial<IconProps>) => <Icon type="calendar-blank" variant="fill" {...props} />,
@@ -59,5 +58,9 @@ const iconConfig: IconConfig = {
   table: (props: Partial<IconProps>) => <Icon type="table" {...props} />,
   link: (props: Partial<IconProps>) => <Icon type="link-simple-break" {...props} />,
   linkBreak: (props: Partial<IconProps>) => <Icon type="link" {...props} />,
+  success: (props: Partial<IconProps>) => <Icon type="check-circle" variant="fill" {...props} />,
+  info: (props: Partial<IconProps>) => <Icon type="info" variant="fill" {...props} />,
+  danger: (props: Partial<IconProps>) => <Icon type="x-circle" variant="fill" {...props} />,
+  warning: (props: Partial<IconProps>) => <Icon type="warning-circle" variant="fill" {...props} />,
 };
 export default iconConfig;

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -1210,16 +1210,36 @@ const defaultComponentConfig = {
     actions: {
       master: "mt-2 space-x-2",
       borderColor: "border-primary",
+      noCloseButton: {
+        container: "flex border-l pl-2",
+        innerContainer: "-ml-px flex flex-col",
+      },
     },
     Container: {
       master: "w-full max-w-sm pointer-events-auto",
-      backgroundColor: "bg-white",
+      backgroundColor: {
+        info: "bg-info-light",
+        danger: "bg-danger-light",
+        warning: "bg-warning-light",
+        success: "bg-success-light",
+        default: "bg-white",
+      },
       borderRadius: "rounded-xl",
       boxShadow: "drop-shadow-xl",
-      outer: {
+      inner: {
         base: "rounded-lg flex items-start shadow-xs overflow-hidden ",
         regular: "p-3",
         condensed: "p-2",
+      },
+      content: "flex-1 ml-3",
+    },
+    icon: {
+      master: "flex-shrink-0",
+      type: {
+        info: "text-info",
+        danger: "text-danger",
+        warning: "text-warning",
+        success: "text-success",
       },
     },
     dismiss: {
@@ -1976,9 +1996,11 @@ const defaultComponentConfig = {
 
 const defaultTheme = createTheme({ component: defaultComponentConfig });
 
+export type IconVariant = "thin" | "light" | "regular" | "bold" | "fill";
 export type IconProps = {
   size: number;
   className: string;
+  variant: IconVariant;
 };
 
 export type IconConfig = {
@@ -1989,7 +2011,6 @@ export type IconConfig = {
   paginatorPrevious: (props: Partial<IconProps>) => React.ReactElement;
   paginatorNext: (props: Partial<IconProps>) => React.ReactElement;
   completed: (props: Partial<IconProps>) => React.ReactElement;
-  warning: (props: Partial<IconProps>) => React.ReactElement;
   sortDesc: (props: Partial<IconProps>) => React.ReactElement;
   sortAsc: (props: Partial<IconProps>) => React.ReactElement;
   date: (props: Partial<IconProps>) => React.ReactElement;
@@ -2019,9 +2040,13 @@ export type IconConfig = {
   table: (props: Partial<IconProps>) => React.ReactElement;
   link: (props: Partial<IconProps>) => React.ReactElement;
   linkBreak: (props: Partial<IconProps>) => React.ReactElement;
+  success: (props: Partial<IconProps>) => React.ReactElement;
+  info: (props: Partial<IconProps>) => React.ReactElement;
+  danger: (props: Partial<IconProps>) => React.ReactElement;
+  warning: (props: Partial<IconProps>) => React.ReactElement;
 };
 
-export const defaultIconConfig = {
+export const defaultIconConfig: IconConfig = {
   dismiss: (props: Partial<IconProps>) => <span className={props.className}>&times;</span>,
   breadcrumbs: (props: Partial<IconProps>) => <span className={props.className}>&gt;</span>,
   openExpander: (props: Partial<IconProps>) => <span className={props.className}>-</span>,
@@ -2029,7 +2054,6 @@ export const defaultIconConfig = {
   paginatorPrevious: (props: Partial<IconProps>) => <span className={props.className}>&lt;</span>,
   paginatorNext: (props: Partial<IconProps>) => <span className={props.className}>&gt;</span>,
   completed: (props: Partial<IconProps>) => <span className={props.className}>✓</span>,
-  warning: (props: Partial<IconProps>) => <span className={props.className}>!</span>,
   sortDesc: (props: Partial<IconProps>) => <span className={props.className}>↓</span>,
   sortAsc: (props: Partial<IconProps>) => <span className={props.className}>↑</span>,
   date: (props: Partial<IconProps>) => <span className={props.className}></span>,
@@ -2059,6 +2083,10 @@ export const defaultIconConfig = {
   table: (props: Partial<IconProps>) => <span className={props.className}></span>,
   link: (props: Partial<IconProps>) => <span className={props.className}></span>,
   linkBreak: (props: Partial<IconProps>) => <span className={props.className}></span>,
+  success: (props: Partial<IconProps>) => <span className={props.className}>&#9745;</span>,
+  info: (props: Partial<IconProps>) => <span className={props.className}>&#9432;</span>,
+  danger: (props: Partial<IconProps>) => <span className={props.className}>X</span>,
+  warning: (props: Partial<IconProps>) => <span className={props.className}>!</span>,
 };
 
 export type Theme = {

--- a/libs/theme/src/defaultTheme.tsx
+++ b/libs/theme/src/defaultTheme.tsx
@@ -1226,7 +1226,7 @@ const defaultComponentConfig = {
       },
       borderRadius: "rounded-xl",
       boxShadow: "drop-shadow-xl",
-      inner: {
+      outer: {
         base: "rounded-lg flex items-start shadow-xs overflow-hidden ",
         regular: "p-3",
         condensed: "p-2",

--- a/libs/theme/src/index.tsx
+++ b/libs/theme/src/index.tsx
@@ -21,6 +21,7 @@ import {
   ThemeConfigFactory as InternalThemeConfigFactory,
   IconConfig as InternalIconConfig,
   IconProps as InternalIconProps,
+  IconVariant as InternalIconVariant,
 } from "./defaultTheme";
 import { TokenProps as InternalTokenProps, ComponentTokens as InternalComponentTokens } from "./useTokens";
 
@@ -29,6 +30,7 @@ export type ThemeConfigFactory = InternalThemeConfigFactory;
 export type ThemeComponentType = InternalThemeComponentType;
 export type IconConfig = InternalIconConfig;
 export type IconProps = InternalIconProps;
+export type IconVariant = InternalIconVariant;
 export type TokenProps<T extends ThemeComponentType> = InternalTokenProps<T>;
 export type ComponentTokens<T extends ThemeComponentType> = InternalComponentTokens<T>;
 

--- a/libs/theme/src/useIcon.tsx
+++ b/libs/theme/src/useIcon.tsx
@@ -26,14 +26,18 @@ type AppIconType = keyof IconConfig;
 export default function useIcon(
   iconName: AppIconType,
   override?: React.ReactElement,
-  iconProps?: Partial<IconProps>
+  iconProps?: Partial<IconProps>,
 ): React.ReactElement {
   const { icons } = useThemeContext();
   if (override !== undefined) {
-    return React.cloneElement(override, { className: iconProps?.className, size: iconProps?.size });
+    return React.cloneElement(override, {
+      className: iconProps?.className,
+      size: iconProps?.size,
+      variant: iconProps?.variant,
+    });
   }
 
-  const { size = 5, className = "" } = iconProps ?? {};
+  const { size = 5, className = "", variant = "regular" } = iconProps ?? {};
 
-  return icons[iconName]({ size, className });
+  return icons[iconName]({ size, className, variant });
 }

--- a/storybook/src/alert/Notification.mdx
+++ b/storybook/src/alert/Notification.mdx
@@ -1,9 +1,9 @@
-import { Meta, ArgsTable, Story, Canvas } from "@storybook/addon-docs";
+import { Meta, ArgsTable, Stories } from "@storybook/addon-docs";
 
 import { Notification } from "@tiller-ds/alert";
 import { ThemeTokens } from "../utils";
 
-<Meta title="Docs|Notification" component={ Notification } />
+<Meta title="Docs|Notification" component={Notification} />
 
 # Notification
 
@@ -17,51 +17,19 @@ The `title` is the only required prop to be passed onto the component.
 All props are described on the [Notification Props section](/docs/component-library-alert-notification--with-actions-right#notification-props)
 of the documentation.
 
-An example of the simple notification with a title, description, icon and a close button is represented below:
-
-### Simple Notification
-
-<Canvas>
-  <Story id="component-library-alert-notification--simple" />
-</Canvas>
-
-The notification can also contain actions (such as buttons or hyperlinks) by passing an `actions`
-prop to the component. These elements are rendered below the `description` of the notification:
-
-### With Actions
-
-<Canvas>
-  <Story id="component-library-alert-notification--with-actions-below" />
-</Canvas>
-
-### With Buttons
-
-<Canvas>
-  <Story id="component-library-alert-notification--with-buttons-below" />
-</Canvas>
-
-If `onDismiss` prop is included, the close button (X) appears on the right side of the component and
-closes the notification by default.
-If `onDismiss` prop is not included, the actions passed onto the component appear on the right side
-of the component, instead of the close button:
-
-### With Actions Right (Without Close Button)
-
-<Canvas>
-  <Story id="component-library-alert-notification--with-actions-right" />
-</Canvas>
-
 ## Best Practices
 
 - Include the `icon` prop when displaying a notification, that way the notification is more visually
-attractive and noticeable
+  attractive and noticeable
 - Prefer using the `description` prop when handling complex operations to give the user more info on the
-details of the action
+  details of the action
 - As a rule, avoid disabling the `closeButton` prop because it gives the user more control over a notification by
-enabling him to close the notification and avoid distractions rather than waiting for the notification
-to disappear by itself
+  enabling him to close the notification and avoid distractions rather than waiting for the notification
+  to disappear by itself
 
-### __Important Notice:__
+<Stories includePrimary={true} />
+
+### **Important Notice:**
 
 **For notifications to function properly, wrap your desired routes with a `NotificationProvider` component.**
 
@@ -72,10 +40,10 @@ notification with **`.push`** method.
 Find out more about the `NotificationProvider`, along with examples on
 how to summon your notification [here](/docs/component-library-alert-notificationprovider--example).
 
-
 ## Notification Props:
 
 <ArgsTable of={Notification} />
 
 ## Notification Tokens:
-<ThemeTokens component="Notification"/>
+
+<ThemeTokens component="Notification" />

--- a/storybook/src/alert/Notification.stories.tsx
+++ b/storybook/src/alert/Notification.stories.tsx
@@ -44,6 +44,14 @@ export default {
 
 export const Simple = () => (
   <Notification
+    title={<Intl name="notificationTitle" />}
+    content={<Intl name="notificationContent" />}
+    onDismiss={() => {}}
+  />
+);
+
+export const WithIcon = () => (
+  <Notification
     icon={<Icon type="check-circle" size={6} variant="fill" className="text-success" />}
     title={<Intl name="notificationTitle" />}
     content={<Intl name="notificationContent" />}
@@ -111,4 +119,65 @@ export const WithActionsRight = () => (
       </Link>,
     ]}
   />
+);
+
+export const WithPredefinedStyle = () => (
+  <Notification
+    type="success"
+    title={<Intl name="notificationTitle" />}
+    content={<Intl name="notificationContent" />}
+    onDismiss={() => {}}
+  />
+);
+
+export const WithPredefinedStyleAndNoAccent = () => (
+  <Notification
+    type="success"
+    disableAccent={true}
+    title={<Intl name="notificationTitle" />}
+    content={<Intl name="notificationContent" />}
+    onDismiss={() => {}}
+  />
+);
+
+export const WithPredefinedStyleAndModifiedIcons = () => (
+  <Notification
+    type="success"
+    iconProps={{
+      mainIcon: { variant: "thin", size: 7, className: "text-success" },
+      dismissIcon: { variant: "thin", size: 4, className: "text-success-dark" },
+    }}
+    title={<Intl name="notificationTitle" />}
+    content={<Intl name="notificationContent" />}
+    onDismiss={() => {}}
+  />
+);
+
+export const AllPredefinedStyles = () => (
+  <div className="flex flex-col space-y-4">
+    <Notification
+      type="success"
+      title={<Intl name="notificationTitle" />}
+      content={<Intl name="notificationContent" />}
+      onDismiss={() => {}}
+    />
+    <Notification
+      type="info"
+      title={<Intl name="notificationTitle" />}
+      content={<Intl name="notificationContent" />}
+      onDismiss={() => {}}
+    />
+    <Notification
+      type="danger"
+      title={<Intl name="notificationTitle" />}
+      content={<Intl name="notificationContent" />}
+      onDismiss={() => {}}
+    />
+    <Notification
+      type="warning"
+      title={<Intl name="notificationTitle" />}
+      content={<Intl name="notificationContent" />}
+      onDismiss={() => {}}
+    />
+  </div>
 );

--- a/storybook/src/alert/NotificationProvider.stories.tsx
+++ b/storybook/src/alert/NotificationProvider.stories.tsx
@@ -97,6 +97,21 @@ function Content() {
     onDismiss: () => {},
   };
 
+  const withPredefinedStyle: NotificationProps = {
+    title: "With Predefined Style",
+    content: "Simple styled notification.",
+    type: "success",
+    onDismiss: () => {},
+  };
+
+  const withPredefinedStyleNoAccent: NotificationProps = {
+    title: "With Predefined Style",
+    content: "Simple styled notification without accent background.",
+    type: "success",
+    disableAccent: true,
+    onDismiss: () => {},
+  };
+
   return (
     <div className="flex flex-col w-1/4 space-y-2">
       <Button onClick={() => notifications.push(simple)}>Simple</Button>
@@ -105,6 +120,10 @@ function Content() {
       <Button onClick={() => notifications.push(withActionsBelow)}>With Actions Below</Button>
       <Button onClick={() => notifications.push(withButtonsBelow)}>With Buttons Below</Button>
       <Button onClick={() => notifications.push(withActionsRight)}>With Actions Right</Button>
+      <Button onClick={() => notifications.push(withPredefinedStyle)}>With Predefined Style</Button>
+      <Button onClick={() => notifications.push(withPredefinedStyleNoAccent)}>
+        With Predefined Style and No Accent
+      </Button>
     </div>
   );
 }
@@ -125,11 +144,15 @@ function Notification({ label }) {
     icon: <Icon type="check-circle" size={6} variant="fill" className="text-emerald-500" />,
   };
 
-  return <Button onClick={() => notifications.push(withIcon)}>{label}</Button>;
+  return (
+    <Button className="w-[250px]" onClick={() => notifications.push(withIcon)}>
+      {label}
+    </Button>
+  );
 }
 
 export const DifferentPositions = () => (
-  <div className="flex flex-col w-1/4 space-y-2">
+  <div className="flex flex-col w-full mt-32 space-y-2 justify-center items-center">
     <NotificationProvider>
       <Notification label="Top Right" />
     </NotificationProvider>


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version:
  1.15.1
* Module: alert

## Description

### Summary

Expanded `Notification`'s customization capabilities by adding additional props:
- `type` - changes the default look and feel of the notification (`success`/`info`/`danger`/`warning`)
- `disableAccent` - disables the accent background color that follows the `type` prop's look and feel
- `iconProps` - enables modifying `size`, `className` and `variant` props of default main and dismiss icons


Other improvements:
- improved tokens by moving all remaining classes into tokens
- added `success`, `info`, `danger` and `warning` default icons into default icon config
- reduced the size of `Notification`'s default dismiss button to a more appropriate size


### Related issue

#283 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Enhancement (non-breaking change which enhances existing functionality)
- New feature (non-breaking change which adds functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added a story to cover my changes
- [x] All new and existing story tests pass
