### PR TITLE
#287 Extend type of title prop on TopNavigation and SidebarNavigation

### DIFF
--- a/libs/menu/src/SidebarNavigation.tsx
+++ b/libs/menu/src/SidebarNavigation.tsx
@@ -97,7 +97,7 @@ type SidebarNavigationItemProps = {
    * Defines the title of the item. If the 'isExpandable' prop is not set to true (which is by default),
    * this prop is not required. In that case, you can set the title via the 'children' prop.
    */
-  title?: string;
+  title?: React.ReactNode;
 
   /**
    * Custom additional class name for the main container component.
@@ -147,7 +147,7 @@ type SidebarNavigationDropdownProps = {
   /**
    * Title of the Dropdown menu, shown only if text variant of the dropdown is selected.
    */
-  title: string;
+  title: React.ReactNode;
 
   /**
    * Determines the button color for the dropdown. Accepts many colors, along with your brand colors

--- a/libs/menu/src/TopNavigation.tsx
+++ b/libs/menu/src/TopNavigation.tsx
@@ -119,7 +119,7 @@ export type TopNavigationItemProps = {
    * Defines the title of the item. If the 'isExpandable' prop is not set to true (which is by default),
    * this prop is not required. In that case, you can set the title via the 'children' prop.
    */
-  title?: string;
+  title?: React.ReactNode;
 
   /**
    * Destination url.
@@ -148,7 +148,7 @@ type TopNavigationDropdownProps = {
   /**
    * Title of the Dropdown menu, shown only if text variant of the dropdown is selected.
    */
-  title: string;
+  title: React.ReactNode;
 
   /**
    * Custom icon serving as a dropdown menu open button.


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.15.1
* Module: menu

## Description

### Summary

Expanded `title` prop on `TopNavigation` and `SidebarNavigation` components by changing its type:

- Old type - `string`
- New type - `React.ReactNode`

### Related issue

#287 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
