### PR TITLE
#291 Fix `Select(Field)` not working with 0 value

### DIFF
--- a/libs/formik-elements/src/SelectField.tsx
+++ b/libs/formik-elements/src/SelectField.tsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 
-import { useField, useFormikContext } from "formik";
+import { useField } from "formik";
 import { isEqual } from "lodash";
 
 import { Select, SelectProps } from "@tiller-ds/selectors";
@@ -43,7 +43,6 @@ function find<T>(value: T, arr: T[]) {
 }
 
 function SelectField<T>({ name, getOptionValue, children, options, ...props }: SelectFieldProps<T>) {
-  const formik = useFormikContext();
   const [field, meta, helpers] = useField(name);
   const shouldValidate = useShouldValidate();
   const initialError = useFormikBypass(name);
@@ -63,11 +62,11 @@ function SelectField<T>({ name, getOptionValue, children, options, ...props }: S
   const value = field.value && (Array.isArray(field.value) ? field.value.map(optionFn) : optionFn(field.value));
 
   const onChange = (item: T | T[] | undefined) => {
-    if (item) {
+    if (item != null) {
       if (Array.isArray(item)) {
         helpers.setValue(item.map(valueFn), shouldValidate);
       } else {
-        helpers.setValue(item && valueFn(item), shouldValidate);
+        helpers.setValue(valueFn(item), shouldValidate);
       }
     } else {
       helpers.setTouched(true, shouldValidate);

--- a/libs/formik-elements/src/SelectField.tsx
+++ b/libs/formik-elements/src/SelectField.tsx
@@ -18,7 +18,7 @@
 import React from "react";
 
 import { useField } from "formik";
-import { isEqual } from "lodash";
+import { isEqual, isNil } from "lodash";
 
 import { Select, SelectProps } from "@tiller-ds/selectors";
 import useShouldValidate from "./useShouldValidate";
@@ -62,7 +62,7 @@ function SelectField<T>({ name, getOptionValue, children, options, ...props }: S
   const value = field.value && (Array.isArray(field.value) ? field.value.map(optionFn) : optionFn(field.value));
 
   const onChange = (item: T | T[] | undefined) => {
-    if (item != null) {
+    if (!isNil(item)) {
       if (Array.isArray(item)) {
         helpers.setValue(item.map(valueFn), shouldValidate);
       } else {

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -18,8 +18,9 @@
 import * as React from "react";
 
 import { useSelect, UseSelectStateChangeTypes } from "downshift";
-import Popover, { positionMatchWidth } from "@reach/popover";
+import { isNil } from "lodash";
 
+import Popover, { positionMatchWidth } from "@reach/popover";
 import { Field } from "@tiller-ds/form-elements";
 import { useLabel } from "@tiller-ds/intl";
 import { ComponentTokens, cx, useIcon, useTokens } from "@tiller-ds/theme";
@@ -197,7 +198,7 @@ function Select<T>({
   const id = `input-${name}`;
   const isDisabled = disabled || loading;
   const hasOptions = options.length !== 0;
-  const hasValue = value != null;
+  const hasValue = !isNil(value);
 
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   //used only for form submit on enter
@@ -240,7 +241,7 @@ function Select<T>({
         if (allowMultiple) {
           const currentValue = hasValue && Array.isArray(value) ? [...value] : [];
 
-          if (selectedItem != null) {
+          if (!isNil(selectedItem)) {
             const index = currentValue.indexOf(selectedItem);
 
             if (index === -1) {
@@ -253,7 +254,7 @@ function Select<T>({
           } else {
             onChange([]);
           }
-        } else if (selectedItem != null) {
+        } else if (!isNil(selectedItem)) {
           onChange(selectedItem);
         }
       } else if (type === useSelect.stateChangeTypes.MenuBlur) {
@@ -332,7 +333,7 @@ function Select<T>({
     </div>
   );
   const singleOptionLabelFn = (singleValue?: T | null) =>
-    singleValue != null ? optionLabelFn(singleValue) : placeholderElement;
+    !isNil(singleValue) ? optionLabelFn(singleValue) : placeholderElement;
   const selectedFn = (array: T[]) =>
     getMultipleSelectedLabel ? getMultipleSelectedLabel(array) : `${array.length} selected`;
   const arrayLabelFn = (array: T[]) => (array.length <= 1 ? singleOptionLabelFn(array[0]) : selectedFn(array));

--- a/libs/selectors/src/Select.tsx
+++ b/libs/selectors/src/Select.tsx
@@ -197,6 +197,7 @@ function Select<T>({
   const id = `input-${name}`;
   const isDisabled = disabled || loading;
   const hasOptions = options.length !== 0;
+  const hasValue = value != null;
 
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   //used only for form submit on enter
@@ -237,9 +238,9 @@ function Select<T>({
 
       if (selectionTypes.indexOf(type) !== -1 || type === useSelect.stateChangeTypes.FunctionReset) {
         if (allowMultiple) {
-          const currentValue = value && Array.isArray(value) ? [...value] : [];
+          const currentValue = hasValue && Array.isArray(value) ? [...value] : [];
 
-          if (selectedItem) {
+          if (selectedItem != null) {
             const index = currentValue.indexOf(selectedItem);
 
             if (index === -1) {
@@ -252,7 +253,7 @@ function Select<T>({
           } else {
             onChange([]);
           }
-        } else if (selectedItem) {
+        } else if (selectedItem != null) {
           onChange(selectedItem);
         }
       } else if (type === useSelect.stateChangeTypes.MenuBlur) {
@@ -322,9 +323,7 @@ function Select<T>({
   }, [isOpen]);
 
   const defaultFn = (item: T) => (typeof item === "string" ? item : item["label"]);
-  const defaultIsItemDisabledFn = () => false;
   const optionLabelFn = getOptionLabel || children || defaultFn;
-  const isItemDisabledFn = isItemDisabled || defaultIsItemDisabledFn;
 
   const noResultsText = useLabel("selectNoResults", "No results");
   const placeholderElement = (
@@ -333,7 +332,7 @@ function Select<T>({
     </div>
   );
   const singleOptionLabelFn = (singleValue?: T | null) =>
-    singleValue ? optionLabelFn(singleValue) : placeholderElement;
+    singleValue != null ? optionLabelFn(singleValue) : placeholderElement;
   const selectedFn = (array: T[]) =>
     getMultipleSelectedLabel ? getMultipleSelectedLabel(array) : `${array.length} selected`;
   const arrayLabelFn = (array: T[]) => (array.length <= 1 ? singleOptionLabelFn(array[0]) : selectedFn(array));
@@ -360,7 +359,7 @@ function Select<T>({
 
   const SelectItem = ({ option, index }: { option: T; index: number }) => {
     let element = optionLabelFn(option);
-    const isDisabled = isItemDisabledFn(option);
+    const isDisabled = Boolean(isItemDisabled && isItemDisabled(option));
     const itemProps = !isDisabled && { ...getItemProps({ item: option, index }) };
 
     const itemClassName = (selected: boolean) =>
@@ -432,13 +431,13 @@ function Select<T>({
             <div className={tokens.Loading.container}>
               {loading && <div className={loadingInnerClassName}>{loadingIcon}</div>}
               {error && warningIcon}
-              {!disabled && value && !hideClearButton && !error && (
+              {!disabled && hasValue && !hideClearButton && !error && (
                 <button type="button" className={clearClassName} onClick={clear}>
                   {removeIcon}
                 </button>
               )}
-              <div className={value || error || loading ? tokens.Separator.container : undefined}>
-                {(value || error || loading) && <div className={tokens.Separator.inner}>&nbsp;</div>}
+              <div className={hasValue || error || loading ? tokens.Separator.container : undefined}>
+                {(hasValue || error || loading) && <div className={tokens.Separator.inner}>&nbsp;</div>}
               </div>
             </div>
           </div>

--- a/storybook/src/formik-elements/SelectField.stories.tsx
+++ b/storybook/src/formik-elements/SelectField.stories.tsx
@@ -204,6 +204,17 @@ SelectFieldFactory.parameters = {
   },
 };
 
+export const Test = () => (
+  <SelectField
+    name="test"
+    options={[0, 1]}
+    getOptionLabel={(option) => (!option ? "Nula" : "Jedan")}
+    getOptionValue={(option) => option}
+    label={<Intl name="label" />}
+    allowMultiple={true}
+  />
+);
+
 export const WithLabel = () => <SelectField {...commonProps} label={<Intl name="label" />} />;
 
 export const WithoutLabel = () => <SelectField {...commonProps} />;
@@ -226,7 +237,7 @@ export const DisabledItems = () => (
     {...commonProps}
     label={<Intl name="label" />}
     isItemDisabled={(item: Item) => {
-      return item.name === "Pero";
+      return item.name === "Matthew" || item.name === "John";
     }}
   />
 );

--- a/storybook/src/formik-elements/SelectField.stories.tsx
+++ b/storybook/src/formik-elements/SelectField.stories.tsx
@@ -204,17 +204,6 @@ SelectFieldFactory.parameters = {
   },
 };
 
-export const Test = () => (
-  <SelectField
-    name="test"
-    options={[0, 1]}
-    getOptionLabel={(option) => (!option ? "Nula" : "Jedan")}
-    getOptionValue={(option) => option}
-    label={<Intl name="label" />}
-    allowMultiple={true}
-  />
-);
-
 export const WithLabel = () => <SelectField {...commonProps} label={<Intl name="label" />} />;
 
 export const WithoutLabel = () => <SelectField {...commonProps} />;

--- a/storybook/src/formik-elements/TreeSelectField.stories.tsx
+++ b/storybook/src/formik-elements/TreeSelectField.stories.tsx
@@ -116,7 +116,6 @@ export const WithValueLabel = () => (
   <TreeSelectField
     {...commonProps}
     name="nameWithTreeItem"
-    disabled
     getValueLabel={(item) => (
       <>
         {item.code} {item.name}

--- a/storybook/src/selectors/Select.stories.tsx
+++ b/storybook/src/selectors/Select.stories.tsx
@@ -212,7 +212,7 @@ export const DisabledItems = () => (
     {...commonProps}
     label={<Intl name="label" />}
     isItemDisabled={(item: Item) => {
-      return item.name === "Pero";
+      return item.name === "Matthew" || item.name === "John";
     }}
   />
 );


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.15.1
* Module: selectors

## Description

### Summary

Fixed `Select(Field)`'s broken functionality when 0 is provided as a value (`Select` and `SelectField`) or when 0 is the return value of `getOptionValue` prop (`SelectField`).

### Related issue

<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->
#291 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
