### PR TITLE
#272 Refactor & extend test ID logic to support more components

### DIFF
--- a/libs/alert/src/Alert.tsx
+++ b/libs/alert/src/Alert.tsx
@@ -66,6 +66,19 @@ export type AlertProps = {
    * Icon shown on the left side of the Alert.
    */
   icon?: React.ReactNode;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & AlertTokensProps;
 
 type AlertTokensProps = {
@@ -97,7 +110,7 @@ export default function Alert({
   const textClassName = cx({ [tokens.text.margin]: title }, tokens.text.fontSize, tokens.text.color[variant]);
 
   return (
-    <section className={alertClassName} {...props}>
+    <section className={alertClassName} data-testid={props["data-testid"]} {...props}>
       {icon}
       <div>
         {title && <p className={titleClassName}>{title}</p>}

--- a/libs/alert/src/Modal.tsx
+++ b/libs/alert/src/Modal.tsx
@@ -58,6 +58,18 @@ type ModalContentProps = {
   title: React.ReactNode;
 
   children?: React.ReactNode;
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TokenProps<"Modal">;
 
 type ModalDismissProps = {
@@ -73,10 +85,36 @@ type ModalDismissProps = {
    * Icon uses for dismiss button
    */
   dismissIcon?: React.ReactElement;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TokenProps<"Modal">;
 
 type ModalFooterProps = {
   children?: React.ReactNode;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TokenProps<"Modal">;
 
 type ModalIconProps = {
@@ -89,6 +127,19 @@ type ModalIconProps = {
    * Icon used.
    */
   icon: React.ReactElement;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TokenProps<"Modal">;
 
 export type UseModal<T = unknown> = {
@@ -118,6 +169,19 @@ export type UseModal<T = unknown> = {
    * 'const modal = useModal<string>()' and open the modal with 'modal.onOpen('someString')'.
    */
   state: T | null;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 type ModalContext = {
@@ -198,10 +262,14 @@ function Modal<T = unknown>({
           <div className={tokens.Container.Overlay.outer}>
             <div className={overlayInnerClassName}>&nbsp;</div>
           </div>
-          <DialogContent className={contentContainerClassName} aria-label="Dialog Content">
+          <DialogContent
+            className={contentContainerClassName}
+            aria-label="Dialog Content"
+            data-testid={props["data-testid"]}
+          >
             {canDismiss && (
               <div className={tokens.Container.Content.dismiss}>
-                <ModalDismiss />
+                <ModalDismiss data-testid={`${props["data-testid"]}-dismiss`} />
               </div>
             )}
             <div className={tokens.Container.Content.outer}>
@@ -230,7 +298,13 @@ function ModalDismiss({ ariaLabel = "Close", dismissIcon, ...props }: ModalDismi
   const finalDismissIcon = useIcon("dismiss", dismissIcon);
 
   return (
-    <button onClick={onClose} type="button" className={dismissButtonClassName} aria-label={ariaLabel}>
+    <button
+      onClick={onClose}
+      type="button"
+      className={dismissButtonClassName}
+      aria-label={ariaLabel}
+      data-testid={props["data-testid"]}
+    >
       {finalDismissIcon}
     </button>
   );
@@ -247,26 +321,34 @@ function ModalContent({ title, children, ...props }: ModalContentProps) {
   );
 
   return (
-    <>
+    <div data-testid={props["data-testid"]}>
       <h3 className={contentTitleClassName} id="modal-headline">
         {title}
       </h3>
       <div className={tokens.Content.master}>{children}</div>
-    </>
+    </div>
   );
 }
 
 function ModalFooter({ children, ...props }: ModalFooterProps) {
   const tokens = useTokens("Modal", props.tokens);
 
-  return <div className={tokens.Footer.base}>{React.Children.map(children, (child, index) => child)}</div>;
+  return (
+    <div className={tokens.Footer.base} data-testid={props["data-testid"]}>
+      {React.Children.map(children, (child, index) => child)}
+    </div>
+  );
 }
 
 function ModalIcon({ className, icon, ...props }: ModalIconProps) {
   const tokens = useTokens("Modal", props.tokens);
   const containerClassName = cx(tokens.Icon.base, tokens.Icon.backgroundColor, className);
 
-  return <div className={containerClassName}>{icon}</div>;
+  return (
+    <div className={containerClassName} data-testid={props["data-testid"]}>
+      {icon}
+    </div>
+  );
 }
 
 Modal.Content = ModalContent;

--- a/libs/alert/src/Notification.tsx
+++ b/libs/alert/src/Notification.tsx
@@ -109,6 +109,19 @@ export type NotificationProps = {
    * Custom container (div) className.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & NotificationTokensProps;
 
 type NotificationTokensProps = {
@@ -187,7 +200,7 @@ export default function Notification({
   const dismissClassName = cx(tokens.dismiss.master, tokens.dismiss.margin);
 
   return (
-    <section className={containerClassName}>
+    <section className={containerClassName} data-testid={props["data-testid"]}>
       <div className={innerContainerClassName}>
         {(icon || type) && <div className={tokens.icon.master}>{type ? finalMainIcon : icon}</div>}
         <div className={tokens.Container.content}>

--- a/libs/core/src/Badge.tsx
+++ b/libs/core/src/Badge.tsx
@@ -62,17 +62,17 @@ export type BadgeProps = {
   small?: boolean;
 
   /**
-   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * A unique identifier for testing purposes.
    * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
    * It helps ensure that UI components are behaving as expected across different scenarios.
    * @type {string}
    * @example
    * // Usage:
-   * <MyComponent testId="my-component" />
+   * <MyComponent data-testid="my-component" />
    * // In tests:
    * getByTestId('my-component');
    */
-  testId?: string;
+  "data-testid"?: string;
 
   /**
    * Determines whether the style of the badge is 'filled' (text-color-800, bg-color-100)
@@ -123,7 +123,7 @@ export default function Badge({
   );
 
   return (
-    <span className={containerClassName} data-testid={props.testId} onClick={onClick}>
+    <span className={containerClassName} data-testid={props["data-testid"]} onClick={onClick}>
       {dot && <BadgeDot color={color} variant={variant} />}
       {children}
       {onRemoveButtonClick && (
@@ -132,7 +132,7 @@ export default function Badge({
           small={small}
           variant={variant}
           onClick={onRemoveButtonClick}
-          testId={props.testId}
+          data-testid={props["data-testid"] && `${props["data-testid"]}-remove`}
         />
       )}
     </span>
@@ -151,7 +151,7 @@ function BadgeDot({ color = "white", variant = "filled", ...props }: BadgeDotPro
   );
 }
 
-function BadgeRemoveButton({ color = "white", small, onClick, testId, variant, ...props }: BadgeRemoveButtonProps) {
+function BadgeRemoveButton({ color = "white", small, onClick, variant, testId, ...props }: BadgeRemoveButtonProps) {
   const tokens = useTokens("Badge", props.tokens);
 
   const className = cx(tokens.variant[variant].color[color].removeIcon, {
@@ -159,10 +159,8 @@ function BadgeRemoveButton({ color = "white", small, onClick, testId, variant, .
     "-mr-0.5": small,
   });
 
-  const buttonId = testId && `remove-button-${testId}`;
-
   return (
-    <button type="button" data-testid={buttonId} className={className} onClick={onClick}>
+    <button type="button" data-testid={testId} className={className} onClick={onClick}>
       <svg className="h-2 w-2" stroke="currentColor" fill="none" viewBox="0 0 8 8">
         <path strokeLinecap="round" strokeWidth="1.5" d="M1 1l6 6m0-6L1 7" />
       </svg>

--- a/libs/core/src/Breadcrumbs.tsx
+++ b/libs/core/src/Breadcrumbs.tsx
@@ -21,6 +21,7 @@ import { ComponentTokens, cx, TokenProps, useIcon, useTokens } from "@tiller-ds/
 
 type BreadcrumbProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"Breadcrumbs">;
 
 export type BreadcrumbsProps = {
@@ -38,6 +39,19 @@ export type BreadcrumbsProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & BreadcrumbsTokensProps;
 
 type BreadcrumbsTokensProps = {
@@ -66,7 +80,7 @@ function Breadcrumbs({ children, icon, className, ...props }: BreadcrumbsProps) 
   const breadcrumbIcon = useIcon("breadcrumbs", icon, { className: tokens.iconColor });
 
   return (
-    <nav className="flex">
+    <nav className="flex" data-testid={props["data-testid"]}>
       <ol className={containerClassName}>
         {React.Children.map(
           children,
@@ -98,7 +112,11 @@ function Breadcrumb({ children, ...props }: BreadcrumbProps) {
     tokens.breadcrumb.transitionTimingFunction,
   );
 
-  return <span className={breadcrumbClassname}>{children}</span>;
+  return (
+    <span className={breadcrumbClassname} data-testid={props["data-testid"]}>
+      {children}
+    </span>
+  );
 }
 
 Breadcrumbs.Breadcrumb = Breadcrumb;

--- a/libs/core/src/Button.tsx
+++ b/libs/core/src/Button.tsx
@@ -41,6 +41,7 @@ export type ButtonProps = {
 
   /**
    * The unique identifier of the button.
+   * Assigned as 'data-testid' attribute if 'data-testid' prop is not defined.
    */
   id?: string;
 
@@ -70,17 +71,17 @@ export type ButtonProps = {
   size?: ButtonSize;
 
   /**
-   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * A unique identifier for testing purposes.
    * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
    * It helps ensure that UI components are behaving as expected across different scenarios.
    * @type {string}
    * @example
    * // Usage:
-   * <MyComponent testId="my-component" />
+   * <MyComponent data-testid="my-component" />
    * // In tests:
    * getByTestId('my-component');
    */
-  testId?: string;
+  "data-testid"?: string;
 
   /**
    * Icon on the right side of the button text.
@@ -140,7 +141,7 @@ export default function Button({
       ref={buttonRef}
       className={buttonClassName}
       id={id}
-      data-testid={props.testId || id}
+      data-testid={props["data-testid"] ?? id}
       disabled={disabled}
       {...props}
     >

--- a/libs/core/src/ButtonGroups.tsx
+++ b/libs/core/src/ButtonGroups.tsx
@@ -32,6 +32,19 @@ export type ButtonGroupsProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & ButtonGroupsTokensProps;
 
 type ButtonGroupsTokensProps = {
@@ -53,7 +66,7 @@ function ButtonGroups({ children, className, ...props }: ButtonGroupsProps) {
   const baseClassName = cx(tokens.master, tokens.base, className);
 
   return (
-    <span className={baseClassName}>
+    <span className={baseClassName} data-testid={props["data-testid"]}>
       {React.Children.map(children, (child, key) => (
         <ButtonGroupContext.Provider key={key} value={{ index: key, count: React.Children.count(children) }}>
           {child}
@@ -81,7 +94,7 @@ export function ButtonGroupsButton({
     className,
     "rounded-none -ml-px",
     { "rounded-l-md": index === 0 },
-    { "rounded-r-md": index + 1 === count }
+    { "rounded-r-md": index + 1 === count },
   );
 
   return (
@@ -116,7 +129,7 @@ export function ButtonGroupsIconButton({
   const roundedClassName = cx(
     className,
     { "rounded-l-md": index === 0 },
-    { "rounded-r-md -ml-px": index + 1 === count }
+    { "rounded-r-md -ml-px": index + 1 === count },
   );
 
   return (

--- a/libs/core/src/Card.tsx
+++ b/libs/core/src/Card.tsx
@@ -35,6 +35,19 @@ export type CardProps = {
    * Determines whether the component is expanded by default.
    */
   isExpanded?: boolean;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & React.HTMLAttributes<HTMLDivElement> &
   CardTokensProps;
 
@@ -52,6 +65,8 @@ export type CardHeaderProps = {
   openExpanderIcon?: React.ReactElement;
 
   closeExpanderIcon?: React.ReactElement;
+
+  "data-testid"?: string;
 } & CardTokensProps;
 
 type CardHeaderTitleProps = {
@@ -59,14 +74,17 @@ type CardHeaderTitleProps = {
    * Card header title content (not exclusively text).
    */
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"Card">;
 
 type CardHeaderSubtitleProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"Card">;
 
 type CardHeaderActionsProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
 export type CardBodyProps = {
@@ -81,12 +99,24 @@ export type CardBodyProps = {
    * Removes the spacing (padding) from the body of the card.
    */
   removeSpacing?: boolean;
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & CardTokensProps;
 
 export type CardFooterProps = {
   className?: string;
-
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"Card">;
 
 type CardContextProviderProps = {
@@ -126,18 +156,18 @@ function Card({ children, status = "idle", isExpanded, className = "", ...props 
     tokens.container.backgroundColor,
     tokens.container.boxShadow,
     tokens.container.borderRadius,
-    tokens.container.overflow
+    tokens.container.overflow,
   );
 
   const waitingContainerClassName = cx(
     "absolute w-full h-full top-0 left-0 z-1",
     tokens.waitingContainer.backgroundColor,
-    tokens.waitingContainer.opacity
+    tokens.waitingContainer.opacity,
   );
 
   return (
     <CardContextProvider flag={isExpanded}>
-      <div className={tokens.master}>
+      <div className={tokens.master} data-testid={props["data-testid"]}>
         <div className={containerClassName}>{children}</div>
         {status === "waiting" && (
           <div className={waitingContainerClassName}>
@@ -158,7 +188,7 @@ function CardHeader({ className = "", removeSpacing = false, children, ...props 
     { [tokens.header.padding]: !removeSpacing },
     { [tokens.header.borderBottomWidth]: !removeSpacing },
     { [tokens.header.borderColor]: !removeSpacing },
-    { "cursor-pointer": isExpanded !== undefined }
+    { "cursor-pointer": isExpanded !== undefined },
   );
 
   const title = findChild("CardHeaderTitle", children);
@@ -176,7 +206,7 @@ function CardHeader({ className = "", removeSpacing = false, children, ...props 
 
   if (title || subtitle || actions) {
     return (
-      <div className={cardHeaderClassName} onClick={toggleExpander}>
+      <div className={cardHeaderClassName} onClick={toggleExpander} data-testid={props["data-testid"]}>
         <div className="-ml-4 -mt-4 flex justify-between items-center sm:flex-nowrap">
           <div className="ml-4 mt-4">
             {title}
@@ -191,7 +221,11 @@ function CardHeader({ className = "", removeSpacing = false, children, ...props 
       </div>
     );
   } else {
-    return <div className={cardHeaderClassName}>{children}</div>;
+    return (
+      <div className={cardHeaderClassName} data-testid={props["data-testid"]}>
+        {children}
+      </div>
+    );
   }
 }
 
@@ -202,10 +236,14 @@ export function CardHeaderTitle({ children, ...props }: CardHeaderTitleProps) {
     tokens.header.title.fontSize,
     tokens.header.title.fontWeight,
     tokens.header.title.lineHeight,
-    tokens.header.title.color
+    tokens.header.title.color,
   );
 
-  return <h3 className={cardHeaderTitleClassName}>{children}</h3>;
+  return (
+    <h3 className={cardHeaderTitleClassName} data-testid={props["data-testid"]}>
+      {children}
+    </h3>
+  );
 }
 
 CardHeaderTitle.defaultProps = {
@@ -219,17 +257,25 @@ function CardHeaderSubtitle({ children, ...props }: CardHeaderSubtitleProps) {
     tokens.header.subtitle.marginTop,
     tokens.header.subtitle.fontSize,
     tokens.header.subtitle.lineHeight,
-    tokens.header.subtitle.color
+    tokens.header.subtitle.color,
   );
-  return <p className={cardHeaderSubtitleClassName}>{children}</p>;
+  return (
+    <p className={cardHeaderSubtitleClassName} data-testid={props["data-testid"]}>
+      {children}
+    </p>
+  );
 }
 
 CardHeaderSubtitle.defaultProps = {
   type: "CardHeaderSubtitle",
 };
 
-export function CardHeaderActions({ children }: CardHeaderActionsProps) {
-  return <div className="flex-shrink-0 ml-4 space-x-2">{children}</div>;
+export function CardHeaderActions({ children, ...props }: CardHeaderActionsProps) {
+  return (
+    <div className="flex-shrink-0 ml-4 space-x-2" data-testid={props["data-testid"]}>
+      {children}
+    </div>
+  );
 }
 
 CardHeaderActions.defaultProps = {
@@ -246,7 +292,11 @@ function CardBody({ removeSpacing = false, children, className = "", ...props }:
     return null;
   }
 
-  return <div className={cardBodyClassName}>{children}</div>;
+  return (
+    <div className={cardBodyClassName} data-testid={props["data-testid"]}>
+      {children}
+    </div>
+  );
 }
 
 function CardFooter({ children, className = "", ...props }: CardFooterProps) {
@@ -257,14 +307,18 @@ function CardFooter({ children, className = "", ...props }: CardFooterProps) {
     tokens.footer.borderTopWidth,
     tokens.footer.borderColor,
     tokens.footer.padding,
-    className
+    className,
   );
 
   if (isExpanded === false) {
     return null;
   }
 
-  return <div className={cardFooterClassName}>{children}</div>;
+  return (
+    <div className={cardFooterClassName} data-testid={props["data-testid"]}>
+      {children}
+    </div>
+  );
 }
 
 CardHeader.Title = CardHeaderTitle;

--- a/libs/core/src/Container.tsx
+++ b/libs/core/src/Container.tsx
@@ -30,6 +30,19 @@ export type ContainerProps = {
    * for inner and outer container of the component.
    */
   variant?: "max" | "fullWidth" | "constrainedPadded" | "fullWidthContainer" | "narrowConstrained";
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & ContainerTokensProps;
 
 type ContainerTokensProps = {
@@ -40,7 +53,7 @@ export default function Container({ variant = "max", children, ...props }: Conta
   const tokens = useTokens("Container", props.tokens);
 
   return (
-    <div className={tokens.variant[variant].outerContainer}>
+    <div className={tokens.variant[variant].outerContainer} data-testid={props["data-testid"]}>
       <div className={tokens.variant[variant].innerContainer}>{children}</div>
     </div>
   );

--- a/libs/core/src/IconButton.tsx
+++ b/libs/core/src/IconButton.tsx
@@ -40,6 +40,7 @@ export type IconButtonProps = {
 
   /**
    * Unique identifier passed onto the component.
+   * Assigned as 'data-testid' attribute if 'data-testid' prop is not defined.
    */
   id?: string;
 
@@ -82,6 +83,7 @@ type WithLinkProps = {
   id?: string;
   onClick?: (() => void) | React.MouseEventHandler<HTMLButtonElement>;
   shouldWrap: boolean;
+  "data-testid"?: string;
 };
 
 function WithLink({ children, shouldWrap, onClick, buttonClass, ...props }: WithLinkProps) {
@@ -125,12 +127,19 @@ export default function IconButton({
   return wrapContent(
     <>
       {disabled && (
-        <WithLink shouldWrap={false} id={id} buttonClass={buttonClass}>
+        <WithLink shouldWrap={false} id={id} buttonClass={buttonClass} data-testid={props["data-testid"] ?? id}>
           {React.cloneElement(icon, { className: disabledIconClass })}
         </WithLink>
       )}
       {!disabled && (
-        <WithLink shouldWrap={props.to !== undefined} id={id} onClick={onClick} buttonClass={buttonClass} {...props}>
+        <WithLink
+          shouldWrap={props.to !== undefined}
+          id={id}
+          onClick={onClick}
+          buttonClass={buttonClass}
+          data-testid={props["data-testid"] ?? id}
+          {...props}
+        >
           {icon}
         </WithLink>
       )}

--- a/libs/core/src/Link.tsx
+++ b/libs/core/src/Link.tsx
@@ -39,6 +39,18 @@ export type LinkProps = {
    * Defaults to linkColor defined in the color's configuration of defaultConfig.
    */
   variant?: LinkColor;
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & Omit<ReactRouterLinkProps, "to"> &
   LinkTokensProps;
 
@@ -54,20 +66,20 @@ export default function Link({ children, variant = "main", to, className, ...pro
     tokens.master,
     tokens.base.fontSize,
     tokens.base.fontWeight,
-    tokens.color[variant]
+    tokens.color[variant],
   );
 
   if (to) {
     return (
-      <ReactRouterLink {...props} to={to} className={linkClassName}>
+      <ReactRouterLink {...props} to={to} className={linkClassName} data-testid={props["data-testid"]}>
         {children}
       </ReactRouterLink>
     );
-  } else {
-    return (
-      <a {...props} type="button" className={linkClassName}>
-        {children}
-      </a>
-    );
   }
+
+  return (
+    <a {...props} type="button" className={linkClassName} data-testid={props["data-testid"]}>
+      {children}
+    </a>
+  );
 }

--- a/libs/core/src/Linkify.tsx
+++ b/libs/core/src/Linkify.tsx
@@ -35,6 +35,18 @@ export type LinkifyProps = {
    * Defaults to linkColor defined in the color's configuration of defaultConfig.
    */
   variant?: LinkifyColor;
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & Options &
   LinkTokensProps;
 
@@ -53,5 +65,9 @@ export default function Linkify({ children, variant = "main", nl2br = true, ...p
     ...props,
   } as Options;
 
-  return <LinkifyLibrary options={options}>{children}</LinkifyLibrary>;
+  return (
+    <LinkifyLibrary options={options} data-testid={props["data-testid"]}>
+      {children}
+    </LinkifyLibrary>
+  );
 }

--- a/libs/core/src/PageHeading.tsx
+++ b/libs/core/src/PageHeading.tsx
@@ -32,6 +32,19 @@ export type PageHeadingProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & PageHeadingTokensProps;
 
 type PageHeadingTokensProps = {
@@ -40,10 +53,12 @@ type PageHeadingTokensProps = {
 
 type PageHeadingTitleProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"PageHeading">;
 
 type PageHeadingSubtitleProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"PageHeading">;
 
 type PageHeadingBreadcrumbsProps = {
@@ -56,18 +71,22 @@ type PageHeadingBreadcrumbsProps = {
    * Defines the look of the component, as demonstrated in stories of Breadcrumbs.
    */
   variant?: React.ReactElement;
+  "data-testid"?: string;
 };
 
 type PageHeadingBreadcrumbProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
 type PageHeadingMetaProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"PageHeading">;
 
 type PageHeadingActionsProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 } & TokenProps<"PageHeading">;
 
 function PageHeading({ children, className, ...props }: PageHeadingProps) {
@@ -85,7 +104,7 @@ function PageHeading({ children, className, ...props }: PageHeadingProps) {
   const actions = findChild("PageHeadingActions");
 
   return (
-    <header>
+    <header data-testid={props["data-testid"]}>
       {breadcrumbs && <div className={tokens.breadcrumbs}>{breadcrumbs}</div>}
       <div className={`${tokens.container} ${className}`}>
         {title && (
@@ -101,9 +120,9 @@ function PageHeading({ children, className, ...props }: PageHeadingProps) {
   );
 }
 
-function PageHeadingBreadcrumbs({ children, variant }: PageHeadingBreadcrumbsProps) {
+function PageHeadingBreadcrumbs({ children, variant, ...props }: PageHeadingBreadcrumbsProps) {
   return (
-    <Breadcrumbs icon={variant}>
+    <Breadcrumbs icon={variant} data-testid={props["data-testid"]}>
       {React.Children.map(children, (child) => {
         return <Breadcrumbs.Breadcrumb>{child}</Breadcrumbs.Breadcrumb>;
       })}
@@ -115,8 +134,8 @@ PageHeadingBreadcrumbs.defaultProps = {
   type: "PageHeadingBreadcrumbs",
 };
 
-function PageHeadingBreadcrumb({ children }: PageHeadingBreadcrumbProps) {
-  return <>{children}</>;
+function PageHeadingBreadcrumb({ children, ...props }: PageHeadingBreadcrumbProps) {
+  return <span data-testid={props["data-testid"]}>{children}</span>;
 }
 
 function PageHeadingTitle({ children, ...props }: PageHeadingTitleProps) {
@@ -130,7 +149,11 @@ function PageHeadingTitle({ children, ...props }: PageHeadingTitleProps) {
     tokens.title.lineHeight,
     tokens.title.color,
   );
-  return <h2 className={pageHeadingTitleClassName}>{children}</h2>;
+  return (
+    <h2 className={pageHeadingTitleClassName} data-testid={props["data-testid"]}>
+      {children}
+    </h2>
+  );
 }
 
 PageHeadingTitle.defaultProps = {
@@ -146,7 +169,11 @@ function PageHeadingSubtitle({ children, ...props }: PageHeadingSubtitleProps) {
     tokens.subtitle.lineHeight,
     tokens.subtitle.color,
   );
-  return <p className={pageHeadingSubtitleClassName}>{children}</p>;
+  return (
+    <p className={pageHeadingSubtitleClassName} data-testid={props["data-testid"]}>
+      {children}
+    </p>
+  );
 }
 
 PageHeadingSubtitle.defaultProps = {
@@ -158,7 +185,7 @@ function PageHeadingMeta({ children, ...props }: PageHeadingMetaProps) {
 
   const pageHeadingMeta = cx(tokens.meta.master, tokens.meta.marginTop);
   return (
-    <div className={pageHeadingMeta}>
+    <div className={pageHeadingMeta} data-testid={props["data-testid"]}>
       {React.Children.map(children, (child) => (
         <div className={tokens.meta.child}>{child}</div>
       ))}
@@ -175,7 +202,11 @@ function PageHeadingActions({ children, ...props }: PageHeadingActionsProps) {
 
   const pageHeadingActionsClassName = cx(tokens.actions.master, tokens.actions.marginTop, tokens.actions.marginLeft);
 
-  return <div className={pageHeadingActionsClassName}>{children}</div>;
+  return (
+    <div className={pageHeadingActionsClassName} data-testid={props["data-testid"]}>
+      {children}
+    </div>
+  );
 }
 
 PageHeadingActions.defaultProps = {

--- a/libs/core/src/Pagination.tsx
+++ b/libs/core/src/Pagination.tsx
@@ -87,6 +87,19 @@ export type PaginationProps = {
    * Defines the total number of elements on a source that the component is hooked up to.
    */
   totalElements: number;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & PaginationTokensProps;
 
 type PaginationTokensProps = {
@@ -162,7 +175,7 @@ export default function Pagination(props: PaginationProps) {
   };
 
   return (
-    <section className={tokens.master}>
+    <section className={tokens.master} data-testid={props["data-testid"]}>
       {pageSummary && <PageSummary {...props} />}
       <Pager {...props} {...calculatedProps} />
     </section>
@@ -192,7 +205,7 @@ function PageSummary({ pageNumber, pageSize, totalElements, children, ...props }
   }
 
   return (
-    <p className={pageSummaryClassName}>
+    <p className={pageSummaryClassName} data-testid={props["data-testid"] && `${props["data-testid"]}-summary`}>
       {intl ? (
         <Intl
           name={intl.commonKeys["paginationSummary"] as string}
@@ -267,6 +280,7 @@ function Pager({
           tokens={defaultButtonTokens}
           disabled={pageNumber === 0 || totalElements === 0}
           onClick={() => onPageChange && onPageChange(pageNumber - 1)}
+          data-testid={props["data-testid"] && `${props["data-testid"]}-previous`}
         >
           {iconPrevious}
         </ButtonGroups.IconButton>
@@ -281,6 +295,7 @@ function Pager({
                 size={displayType === "DESKTOP" ? "md" : "sm"}
                 tokens={defaultButtonTokens}
                 className="cursor-default"
+                data-testid={props["data-testid"] && `${props["data-testid"]}-${value}`}
               >
                 ...
               </ButtonGroups.Button>
@@ -296,6 +311,7 @@ function Pager({
               size={displayType === "DESKTOP" ? "md" : "sm"}
               tokens={pageNumber + 1 === value ? currentButtonTokens : defaultButtonTokens}
               onClick={() => onPageChange && onPageChange(value - 1)}
+              data-testid={props["data-testid"] && `${props["data-testid"]}-${value}`}
             >
               {value}
             </ButtonGroups.Button>
@@ -310,6 +326,7 @@ function Pager({
           tokens={defaultButtonTokens}
           disabled={pageNumber + 1 === pageCount || totalElements === 0}
           onClick={() => onPageChange && onPageChange(pageNumber + 1)}
+          data-testid={props["data-testid"] && `${props["data-testid"]}-next`}
         >
           {iconNext}
         </ButtonGroups.IconButton>

--- a/libs/core/src/Placeholder.tsx
+++ b/libs/core/src/Placeholder.tsx
@@ -19,9 +19,22 @@ import * as React from "react";
 
 type PlaceholderProps = {
   className: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
-export default function Placeholder({ className }: PlaceholderProps) {
+export default function Placeholder({ className, ...props }: PlaceholderProps) {
   return (
     <svg
       className={`border-2 border-dashed border-gray-300 rounded bg-white w-full ${className} text-gray-200`}
@@ -29,6 +42,7 @@ export default function Placeholder({ className }: PlaceholderProps) {
       stroke="currentColor"
       fill="none"
       viewBox="0 0 200 200"
+      data-testid={props["data-testid"]}
     >
       <path vectorEffect="non-scaling-stroke" strokeWidth="2" d="M0 0l200 200M0 200L200 0" />
     </svg>

--- a/libs/core/src/ProgressBar.tsx
+++ b/libs/core/src/ProgressBar.tsx
@@ -47,6 +47,19 @@ export type ProgressBarProps = {
    * Custom step separator shown between steps.
    */
   separator?: React.ReactNode;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & ProgressBarTokensProps;
 
 type ProgressBarTokensProps = {
@@ -69,6 +82,19 @@ type StepProps = {
    * Icon used when step is completed.
    */
   completedIcon?: React.ReactElement;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & ProgressBarTokensProps;
 
 type StepContext = {
@@ -78,6 +104,7 @@ type StepContext = {
   endingIndex: number;
   completed: boolean;
   separator: React.ReactNode;
+  testId?: string;
 };
 
 const StepContext = createNamedContext<StepContext>("StepContext", {
@@ -115,13 +142,23 @@ function ProgressBar({
   const endingIndex = React.Children.toArray(children).length - 1;
 
   const childrenWithIndex = React.Children.map(children, (child, index) => (
-    <StepContext.Provider value={{ activeStepIndex, index, startingIndex, endingIndex, completed, separator }}>
+    <StepContext.Provider
+      value={{
+        activeStepIndex,
+        index,
+        startingIndex,
+        endingIndex,
+        completed,
+        separator,
+        testId: props["data-testid"] && `${props["data-testid"]}-${startingIndex + index}`,
+      }}
+    >
       {child}
     </StepContext.Provider>
   ));
 
   return (
-    <nav>
+    <nav data-testid={props["data-testid"]}>
       <ul className={containerClassName}>{childrenWithIndex}</ul>
     </nav>
   );
@@ -129,7 +166,8 @@ function ProgressBar({
 
 export function Step({ active, children, ...props }: StepProps) {
   const tokens = useTokens("ProgressBar", props.tokens);
-  const { activeStepIndex, index, startingIndex, endingIndex, completed, separator } = React.useContext(StepContext);
+  const { activeStepIndex, index, startingIndex, endingIndex, completed, separator, testId } =
+    React.useContext(StepContext);
 
   const before = index < activeStepIndex;
   const after = index > activeStepIndex;
@@ -171,7 +209,7 @@ export function Step({ active, children, ...props }: StepProps) {
   const stepSeparator = separator ?? <DefaultSeparator />;
 
   return (
-    <li className="relative md:flex-1 md:flex">
+    <li className="relative md:flex-1 md:flex" data-testid={props["data-testid"] ?? testId}>
       <div className="group flex items-center">
         <div className={stepContainerClassName}>
           <div className={indexIconDivClassName}>{content}</div>

--- a/libs/core/src/Tabs.tsx
+++ b/libs/core/src/Tabs.tsx
@@ -62,6 +62,19 @@ type TabsProps = {
    * Custom additional class name for the main container.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TabsTokenProps;
 
 type TabsTokenProps = {
@@ -94,6 +107,19 @@ type TabsTabProp = {
    * Takes the index of the selected tab as a parameter.
    */
   onClick?: (selectedIndex: number) => void;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 export type CustomTabProps = {
@@ -139,6 +165,19 @@ export type CustomTabProps = {
    * Make text unwrappable.
    */
   dontWrapText?: boolean;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TokenProps<"Tabs">;
 
 type CustomTabsProps = {
@@ -242,6 +281,7 @@ function Tabs({
             dontWrapText={scrollButtons}
             className={child.props.className}
             tokens={tokens}
+            data-testid={child.props["data-testid"] ? child.props["data-testid"] : `${props["data-testid"]}-${key}`}
           >
             {child.props.label}
           </CustomTab>
@@ -262,7 +302,7 @@ function Tabs({
 
   return (
     <CustomTabsContext.Provider value={tabsContext}>
-      <ReachTabs defaultIndex={defaultIndex} index={index} onChange={onTabChange}>
+      <ReachTabs defaultIndex={defaultIndex} index={index} onChange={onTabChange} data-testid={props["data-testid"]}>
         <WithScrollButtons shouldWrap={scrollButtons}>
           <TabList className={className}>
             <CustomTabs hasScrollButtons={scrollButtons} tokens={tokens}>
@@ -432,7 +472,7 @@ function CustomTab({
 
   return (
     <div className={tabClassName} onClick={handleClick} ref={tab}>
-      <ReachTab className={tabWrapperClassName} as="a">
+      <ReachTab className={tabWrapperClassName} as="a" data-testid={props["data-testid"]}>
         {icon && <div className={iconClassName}>{icon}</div>}
         {children}
       </ReachTab>

--- a/libs/core/src/Tooltip.tsx
+++ b/libs/core/src/Tooltip.tsx
@@ -36,6 +36,19 @@ export type TooltipProps = {
    * Custom additional class name for the main container.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TooltipTokensProps;
 
 type TooltipTokensProps = {
@@ -52,11 +65,11 @@ export default function Tooltip({ children, label, className, ...props }: Toolti
     tokens.borderRadius,
     tokens.fontSize,
     tokens.color,
-    tokens.backgroundColor
+    tokens.backgroundColor,
   );
 
   return (
-    <ReachTooltip className={tooltipClassName} label={<pre>{label}</pre>}>
+    <ReachTooltip className={tooltipClassName} label={<pre data-testid={props["data-testid"]}>{label}</pre>}>
       <div>{children}</div>
     </ReachTooltip>
   );

--- a/libs/core/src/Typography.tsx
+++ b/libs/core/src/Typography.tsx
@@ -54,6 +54,19 @@ export type TypographyProps = {
    * Children of the component (not exclusively text).
    */
   children: React.ReactNode;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TypographyTokensProps;
 
 type TypographyTokensProps = {
@@ -77,14 +90,18 @@ export default function Typography({
     tokens.icon[variant],
     tokens.icon.base,
     { [tokens.icon.marginRight]: iconPlacement === "leading" },
-    { [tokens.icon.marginLeft]: iconPlacement === "trailing" }
+    { [tokens.icon.marginLeft]: iconPlacement === "trailing" },
   );
 
-  const elementNode = <Element className={elementClassName}>{children}</Element>;
+  const elementNode = (
+    <Element className={elementClassName} data-testid={!icon ? props["data-testid"] : undefined}>
+      {children}
+    </Element>
+  );
 
   if (icon) {
     return (
-      <div className={containerClassName}>
+      <div className={containerClassName} data-testid={props["data-testid"]}>
         {iconPlacement === "leading" && <div className={iconClassName}>{icon}</div>}
         {elementNode}
         {iconPlacement === "trailing" && <div className={iconClassName}>{icon}</div>}

--- a/libs/data-display/src/DescriptionList.tsx
+++ b/libs/data-display/src/DescriptionList.tsx
@@ -40,6 +40,19 @@ type DescriptionListProps = {
    * Custom additional class name for the main container.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & DescriptionListTokensProps;
 
 type DescriptionListTokensProps = {
@@ -68,6 +81,19 @@ type DescriptionListItemProps = {
    * Custom additional class name for the main container.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TokenProps<"DescriptionList">;
 
 function DescriptionList({ children, type = "default", className, ...props }: DescriptionListProps) {
@@ -90,7 +116,7 @@ function DescriptionList({ children, type = "default", className, ...props }: De
           <>
             <div className={tokens.Type.clean.itemBase}>{childrenArray[i]}</div>
             <div className={tokens.Type.clean.itemBase}>{childrenArray[i + 1]}</div>
-          </>
+          </>,
         );
         i++;
       } else {
@@ -109,7 +135,7 @@ function DescriptionList({ children, type = "default", className, ...props }: De
       {
         [`${tokens.Type.default.margin} ${tokens.Type.default.border}  ${tokens.Type.default.borderColor}`]:
           type === "default" && index > 0,
-      }
+      },
     );
 
   const transformed = rows.map((child, key) => {
@@ -124,7 +150,11 @@ function DescriptionList({ children, type = "default", className, ...props }: De
 
   const descriptionListContainerClassName = cx(className, tokens.padding);
 
-  return <dl className={descriptionListContainerClassName}>{transformed}</dl>;
+  return (
+    <dl className={descriptionListContainerClassName} data-testid={props["data-testid"]}>
+      {transformed}
+    </dl>
+  );
 }
 
 function DescriptionListItem({ label, children, type = "default", ...props }: DescriptionListItemProps) {
@@ -132,20 +162,20 @@ function DescriptionListItem({ label, children, type = "default", ...props }: De
 
   const descriptionListItemContainerClassName = cx(
     { [tokens.Item.type.default.itemColumnContainer]: type === "default" },
-    { [tokens.Item.type.sameColumn.itemColumnContainer]: type === "same-column" }
+    { [tokens.Item.type.sameColumn.itemColumnContainer]: type === "same-column" },
   );
 
   const descriptionTermClassName = cx(
     { [tokens.Item.type.default.label]: type === "default" },
-    { [tokens.Item.type.sameColumn.label]: type === "same-column" }
+    { [tokens.Item.type.sameColumn.label]: type === "same-column" },
   );
   const descriptionDetailsClassName = cx(
     { [tokens.Item.type.default.content]: type === "default" },
-    { [tokens.Item.type.sameColumn.content]: type === "same-column" }
+    { [tokens.Item.type.sameColumn.content]: type === "same-column" },
   );
 
   return (
-    <div className={descriptionListItemContainerClassName}>
+    <div className={descriptionListItemContainerClassName} data-testid={props["data-testid"]}>
       <dt className={descriptionTermClassName}>
         <Typography variant="subtext" className="font-medium">
           {label}

--- a/libs/data-display/src/FileBrowser.tsx
+++ b/libs/data-display/src/FileBrowser.tsx
@@ -75,6 +75,19 @@ type ChildrenProps<T extends File> = {
    * @default true
    */
   loading?: boolean;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 type ChildrenFunction<T extends File> = (props: ChildrenProps<T>) => React.ReactNode;
@@ -92,6 +105,19 @@ type FileBrowserProps<T extends File> = {
    */
   fetchDirectory: (directory: T, currentPath?: T[]) => Promise<T[]>;
   children?: ChildrenFunction<T>;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 export function FileBrowser<T extends File>(props: FileBrowserProps<T>): JSX.Element {
@@ -157,7 +183,7 @@ export function FileBrowser<T extends File>(props: FileBrowserProps<T>): JSX.Ele
   };
 
   return (
-    <>
+    <div data-testid={props["data-testid"]}>
       {children ? (
         children({
           currentFiles,
@@ -181,9 +207,10 @@ export function FileBrowser<T extends File>(props: FileBrowserProps<T>): JSX.Ele
           icons={true}
           breadcrumbs={true}
           loading={true}
+          data-testid={props["data-testid"] && `${props["data-testid"]}-table`}
         />
       )}
-    </>
+    </div>
   );
 }
 
@@ -197,14 +224,21 @@ function FileBrowserTable<T extends File>({
   breadcrumbs = true,
   icons = true,
   loading = true,
+  ...props
 }: ChildrenProps<T>) {
   return (
     <>
       {breadcrumbs && (
         <div className="flex flex-row h-10">
-          <Breadcrumbs tokens={{ container: { backgroundColor: "bg-transparent" } }}>
+          <Breadcrumbs
+            tokens={{ container: { backgroundColor: "bg-transparent" } }}
+            data-testid={props["data-testid"] && `${props["data-testid"]}-breadcrumbs`}
+          >
             {currentPath.map((folder, index) => (
-              <button onClick={index !== currentPath.length - 1 ? () => goToDirectory(index + 1) : undefined}>
+              <button
+                onClick={index !== currentPath.length - 1 ? () => goToDirectory(index + 1) : undefined}
+                data-testid={props["data-testid"] && `${props["data-testid"]}-breadcrumbs-${index}`}
+              >
                 <Breadcrumbs.Breadcrumb>{folder.name}</Breadcrumbs.Breadcrumb>
               </button>
             ))}
@@ -217,6 +251,7 @@ function FileBrowserTable<T extends File>({
               onClick={goBack}
               showTooltip={false}
               className="ml-2"
+              data-testid={props["data-testid"] && `${props["data-testid"]}-folder-up`}
             />
           )}
         </div>
@@ -231,6 +266,7 @@ function FileBrowserTable<T extends File>({
             </div>
           ) : undefined
         }
+        data-testid={props["data-testid"] && `${props["data-testid"]}-table`}
       >
         <DataTable.Column header="Name" id="name" canSort={false}>
           {(file: File) => (icons ? <DisplayFileIconAndName file={file} /> : <Typography>{file.name}</Typography>)}

--- a/libs/form-elements-advanced/src/RichTextEditor.tsx
+++ b/libs/form-elements-advanced/src/RichTextEditor.tsx
@@ -592,9 +592,22 @@ type RichTextEditorProps = {
    * @param html The updated HTML content.
    */
   onHtmlChange?: (html: string) => void;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
-export default function RichTextEditor({ initialHtml, onHtmlChange }: RichTextEditorProps) {
+export default function RichTextEditor({ initialHtml, onHtmlChange, ...props }: RichTextEditorProps) {
   const linkTokens = useTokens("Link");
   const typographyTokens = useTokens("Typography");
 
@@ -671,7 +684,7 @@ export default function RichTextEditor({ initialHtml, onHtmlChange }: RichTextEd
       <LinkPlugin />
       <HistoryPlugin />
       <ListPlugin />
-      <div className="relative border border-neutral-100 border-t-0">
+      <div className="relative border border-neutral-100 border-t-0" data-testid={props["data-testid"]}>
         <RichTextPlugin
           contentEditable={<ContentEditable className={richTextEditorClasses} style={{ minHeight: 250 }} />}
           placeholder={<div className={placeholderClasses}>Enter some text...</div>}

--- a/libs/form-elements/src/Checkbox.tsx
+++ b/libs/form-elements/src/Checkbox.tsx
@@ -38,6 +38,19 @@ export type CheckboxProps = {
    * Custom class name for the container.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & Omit<React.HTMLProps<HTMLInputElement>, "label"> &
   CheckboxTokensProps;
 
@@ -63,7 +76,7 @@ export default function Checkbox({ id, label, color = "primary", className, ...p
     tokens.borderRadius,
     tokens.boxShadow,
     tokens.color[color],
-    { [tokens.disabled]: props.disabled }
+    { [tokens.disabled]: props.disabled },
   );
 
   const labelClassName = cx(tokens.label.fontSize, tokens.label.color, tokens.label.padding, {
@@ -82,6 +95,7 @@ export default function Checkbox({ id, label, color = "primary", className, ...p
         style={{
           backgroundImage: `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e")`,
         }}
+        data-testid={props["data-testid"]}
       />
       {label && (
         <label htmlFor={id || defaultId} className={labelClassName}>

--- a/libs/form-elements/src/CheckboxGroup.tsx
+++ b/libs/form-elements/src/CheckboxGroup.tsx
@@ -74,7 +74,7 @@ export type CheckboxGroupItemProps = {
    * A string representing the value of the checkbox. This is not displayed on the client-side, but on the server this is the value given to the data submitted with the checkbox's name.
    */
   value: string;
-} & Omit<FieldGroupItemProps, "id" | "children"> &
+} & Omit<FieldGroupItemProps, "id" | "children" | "data-testid"> &
   CheckboxProps;
 
 type CheckboxGroupContext = {
@@ -85,6 +85,8 @@ type CheckboxGroupContext = {
   onChange: (value: string) => () => void;
 
   onBlur?: () => void;
+
+  testId?: string;
 };
 
 const CheckboxGroupContext = React.createContext<CheckboxGroupContext>({
@@ -109,8 +111,10 @@ function CheckboxGroup({ name, children, value, className = "", onChange, onBlur
   };
 
   return (
-    <FieldGroup className={className} {...props}>
-      <CheckboxGroupContext.Provider value={{ name, checked: value, onChange: contextOnChange, onBlur }}>
+    <FieldGroup className={className} {...props} data-testid={props["data-testid"]}>
+      <CheckboxGroupContext.Provider
+        value={{ name, checked: value, onChange: contextOnChange, onBlur, testId: props["data-testid"] }}
+      >
         {children}
         <input className={tokens.input} ref={inputRef} />
       </CheckboxGroupContext.Provider>
@@ -119,11 +123,16 @@ function CheckboxGroup({ name, children, value, className = "", onChange, onBlur
 }
 
 function CheckboxGroupItem({ value, color, disabled, ...props }: CheckboxGroupItemProps) {
-  const { name, checked, onChange, onBlur } = React.useContext(CheckboxGroupContext);
+  const { name, checked, onChange, onBlur, testId } = React.useContext(CheckboxGroupContext);
 
   const id = `${name}-${value}`;
   return (
-    <FieldGroup.Item {...props} id={id} disabled={disabled}>
+    <FieldGroup.Item
+      {...props}
+      id={id}
+      disabled={disabled}
+      data-testid={props["data-testid"] ? `${props["data-testid"]}-wrapper` : testId && `${testId}-${value}-wrapper`}
+    >
       <Checkbox
         id={id}
         name={name}
@@ -133,6 +142,7 @@ function CheckboxGroupItem({ value, color, disabled, ...props }: CheckboxGroupIt
         onChange={onChange(value)}
         onBlur={onBlur}
         disabled={disabled}
+        data-testid={props["data-testid"] ? props["data-testid"] : testId && `${testId}-${value}`}
       />
     </FieldGroup.Item>
   );

--- a/libs/form-elements/src/Field.tsx
+++ b/libs/form-elements/src/Field.tsx
@@ -85,6 +85,19 @@ export type FieldProps = {
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
    */
   tooltip?: React.ReactNode;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & InputTokensProps;
 
 type InputTokensProps = {
@@ -128,11 +141,11 @@ export default function Field({
     errorMessage = <Intl name={errorMessage.toString().replace("intl:", "")} />;
   }
   if (typeof errorMessage !== "string" && !React.isValidElement(errorMessage)) {
-    errorMessage = ""
+    errorMessage = "";
   }
 
   return (
-    <div className={containerClassName}>
+    <div className={containerClassName} data-testid={props["data-testid"]}>
       <FieldLabel id={id} label={label} required={required} tooltip={tooltip} {...props} />
       <div className={fieldClassName}>{children}</div>
       {addonBelow && addonBelow}

--- a/libs/form-elements/src/FieldGroup.tsx
+++ b/libs/form-elements/src/FieldGroup.tsx
@@ -56,6 +56,19 @@ export type FieldGroupProps = {
    * Displays the field items vertically instead of horizontally by default.
    */
   vertical?: boolean;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & FieldGroupTokens;
 
 export type FieldGroupItemProps = {
@@ -70,6 +83,8 @@ export type FieldGroupItemProps = {
   className?: string;
 
   disabled?: boolean;
+
+  "data-testid"?: string;
 } & TokenProps<"FieldGroup">;
 
 type FieldGroupTokens = {
@@ -106,7 +121,7 @@ function FieldGroup({
   );
 
   return (
-    <fieldset>
+    <fieldset data-testid={props["data-testid"]}>
       <legend className={fieldGroupTokens.Group.legend}>
         {label}
         {required && (
@@ -128,7 +143,7 @@ function FieldGroupItem({ label, help, id, children, className = "", disabled, .
   const fieldGroupItemClassName = cx(className, { [tokens.GroupItem.disabled]: disabled });
 
   return (
-    <div className={fieldGroupItemClassName}>
+    <div className={fieldGroupItemClassName} data-testid={props["data-testid"]}>
       <div className={tokens.GroupItem.container}>
         <div className={tokens.GroupItem.content}>{children}</div>
         <div className={tokens.GroupItem.info}>

--- a/libs/form-elements/src/Input.tsx
+++ b/libs/form-elements/src/Input.tsx
@@ -119,17 +119,17 @@ export type InputProps = {
   required?: boolean;
 
   /**
-   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * A unique identifier for testing purposes.
    * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
    * It helps ensure that UI components are behaving as expected across different scenarios.
    * @type {string}
    * @example
    * // Usage:
-   * <MyComponent testId="my-component" />
+   * <MyComponent data-testid="my-component" />
    * // In tests:
    * getByTestId('my-component');
    */
-  testId?: string;
+  "data-testid"?: string;
 
   /**
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
@@ -284,7 +284,7 @@ const Input = React.forwardRef(
             ref={inputRef || ref}
             name={name}
             id={id}
-            data-testid={props.testId || id}
+            data-testid={props["data-testid"] || id}
             disabled={disabled}
             className={inputClassName}
             {...props}
@@ -298,7 +298,11 @@ const Input = React.forwardRef(
         <div className={`absolute flex ${extend ? "items-start top-3" : "items-center inset-y-0"} right-0`}>
           {error && <InputIcon icon={finalWarningIcon} inputId={props.id} trailing={true} />}
           {!disabled && !props.readOnly && props.value && allowClear && finalClearIcon && (
-            <button type="button" onClick={onReset}>
+            <button
+              type="button"
+              onClick={onReset}
+              data-testid={props["data-testid"] && `${props["data-testid"]}-clear`}
+            >
               {finalClearIcon}
             </button>
           )}

--- a/libs/form-elements/src/MaskedInput.tsx
+++ b/libs/form-elements/src/MaskedInput.tsx
@@ -98,7 +98,7 @@ export default function MaskedInput({
       ref={props.inputRef || currentRef}
       name={name}
       id={id}
-      data-testid={id}
+      data-testid={props["data-testid"] ?? id}
       disabled={disabled}
       onChange={onMaskChange}
       placeholder={inputPlaceholder}

--- a/libs/form-elements/src/NumberInput.tsx
+++ b/libs/form-elements/src/NumberInput.tsx
@@ -93,17 +93,17 @@ export type NumberInputProps = {
   required?: boolean;
 
   /**
-   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * A unique identifier for testing purposes.
    * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
    * It helps ensure that UI components are behaving as expected across different scenarios.
    * @type {string}
    * @example
    * // Usage:
-   * <MyComponent testId="my-component" />
+   * <MyComponent data-testid="my-component" />
    * // In tests:
    * getByTestId('my-component');
    */
-  testId?: string;
+  "data-testid"?: string;
 
   /**
    * Custom thousand separator (e.g. "." or ",").
@@ -169,7 +169,7 @@ export default function NumberInput({
   return (
     <ReactNumberFormat
       id={id}
-      data-testid={props.testId || id}
+      data-testid={props["data-testid"] || id}
       name={name}
       decimalSeparator={finalDecimalSeparator}
       thousandSeparator={finalThousandSeparator}

--- a/libs/form-elements/src/RadioGroup.tsx
+++ b/libs/form-elements/src/RadioGroup.tsx
@@ -94,6 +94,8 @@ type RadioGroupContext = {
   onChange: (value: string) => () => void;
 
   onBlur?: () => void;
+
+  testId?: string;
 };
 
 const RadioGroupContext = React.createContext<RadioGroupContext>({
@@ -115,8 +117,10 @@ function RadioGroup({ name, children, value, className = "", onChange, onBlur, .
   };
 
   return (
-    <FieldGroup {...props} className={className}>
-      <RadioGroupContext.Provider value={{ name, checked: value, onChange: contextOnChange, onBlur }}>
+    <FieldGroup {...props} className={className} data-testid={props["data-testid"]}>
+      <RadioGroupContext.Provider
+        value={{ name, checked: value, onChange: contextOnChange, testId: props["data-testid"] }}
+      >
         {children}
         <input className={tokens.input} ref={inputRef} />
       </RadioGroupContext.Provider>
@@ -126,7 +130,7 @@ function RadioGroup({ name, children, value, className = "", onChange, onBlur, .
 
 function RadioGroupItem({ value, disabled, color = "primary", ...props }: RadioGroupItemProps) {
   const tokens = useTokens("RadioGroup", props.tokens);
-  const { name, checked, onChange, onBlur } = React.useContext(RadioGroupContext);
+  const { name, checked, onChange, onBlur, testId } = React.useContext(RadioGroupContext);
 
   const radioGroupItemInputClassName = cx(
     [tokens.master],
@@ -143,7 +147,12 @@ function RadioGroupItem({ value, disabled, color = "primary", ...props }: RadioG
 
   const id = `${name}-${value}`;
   return (
-    <FieldGroup.Item id={id} {...props} className={fieldGroupItemClassName}>
+    <FieldGroup.Item
+      id={id}
+      {...props}
+      className={fieldGroupItemClassName}
+      data-testid={props["data-testid"] ? `${props["data-testid"]}-wrapper` : testId && `${testId}-${value}-wrapper`}
+    >
       <input
         id={id}
         name={name}
@@ -157,6 +166,7 @@ function RadioGroupItem({ value, disabled, color = "primary", ...props }: RadioG
         style={{
           backgroundImage: `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e")`,
         }}
+        data-testid={props["data-testid"] ? props["data-testid"] : testId && `${testId}-${value}`}
       />
     </FieldGroup.Item>
   );

--- a/libs/form-elements/src/Textarea.tsx
+++ b/libs/form-elements/src/Textarea.tsx
@@ -69,17 +69,17 @@ export type TextareaProps = {
   textareaClassName?: string;
 
   /**
-   * A unique identifier for testing purposes, equivalent to the `data-testid` attribute.
+   * A unique identifier for testing purposes.
    * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
    * It helps ensure that UI components are behaving as expected across different scenarios.
    * @type {string}
    * @example
    * // Usage:
-   * <MyComponent testId="my-component" />
+   * <MyComponent data-testid="my-component" />
    * // In tests:
    * getByTestId('my-component');
    */
-  testId?: string;
+  "data-testid"?: string;
 
   /**
    * Tooltip icon and text (on icon hover) displayed on the right of the label.
@@ -147,7 +147,7 @@ export default function Textarea({
       <textarea
         name={name}
         id={id}
-        data-testid={props.testId || id}
+        data-testid={props["data-testid"] || id}
         value={value}
         className={textareaComponentClassName}
         disabled={disabled}

--- a/libs/form-elements/src/Toggle.tsx
+++ b/libs/form-elements/src/Toggle.tsx
@@ -111,10 +111,17 @@ export default function Toggle({
 
   return (
     <div className={divClassName}>
-      <Field {...props}>
+      <Field {...props} data-testid={props["data-testid"] && `${props["data-testid"]}-wrapper`}>
         <div className={tokens.master}>
           {reverse && label && <label className={labelClassName}>{label}</label>}
-          <span role="checkbox" aria-checked={checked} tabIndex={0} onClick={onClick} className={checkboxClassName}>
+          <span
+            role="checkbox"
+            aria-checked={checked}
+            tabIndex={0}
+            onClick={onClick}
+            className={checkboxClassName}
+            data-testid={props["data-testid"]}
+          >
             <span className={toggleClassName}>{checked ? finalCheckedIcon : finalUncheckedIcon}</span>
           </span>
           {!reverse && label && <label className={labelClassName}>{label}</label>}

--- a/libs/icons/src/Icon.tsx
+++ b/libs/icons/src/Icon.tsx
@@ -41,6 +41,19 @@ export type IconProps = {
    * Determines whether the icon is solid (filled) or outlined
    */
   variant?: IconVariant;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & Omit<React.SVGProps<SVGSVGElement>, "color">;
 
 export default function Icon({ variant = "regular", type, className = "", size = 5, ...props }: IconProps) {
@@ -67,5 +80,5 @@ export default function Icon({ variant = "regular", type, className = "", size =
     [`ph-${type}-${variant}`]: variant !== "regular",
   });
 
-  return <i className={iconClassName} style={{ ...props.style }} />;
+  return <i className={iconClassName} style={{ ...props.style }} data-testid={props["data-testid"]} />;
 }

--- a/libs/icons/src/LoadingIcon.tsx
+++ b/libs/icons/src/LoadingIcon.tsx
@@ -30,13 +30,32 @@ type LoadingIconProps = {
    * Custom additional class name for the svg icon.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
-export default function LoadingIcon({ size = 5, className = "" }: LoadingIconProps) {
+export default function LoadingIcon({ size = 5, className = "", ...props }: LoadingIconProps) {
   const svgClassName = cx("spinner", `w-${size} h-${size}`, className);
 
   return (
-    <svg className={svgClassName} viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+    <svg
+      className={svgClassName}
+      viewBox="0 0 66 66"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      data-testid={props["data-testid"]}
+    >
       <circle
         className="path stroke-current"
         fill="none"

--- a/libs/menu/src/Dropdown.tsx
+++ b/libs/menu/src/Dropdown.tsx
@@ -34,6 +34,19 @@ type DropdownProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 type DropdownContentProps = {
@@ -45,10 +58,24 @@ type DropdownContentProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 type DropdownButtonProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
 type DropdownItemProps = {
@@ -61,6 +88,19 @@ type DropdownItemProps = {
    * Custom function witch fires on selection of the item.
    */
   onSelect: () => void;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 type DropdownContext = {
@@ -75,12 +115,12 @@ export const DropdownContext = createNamedContext<DropdownContext>("DropdownCont
   setItemHeight: (height: number) => {},
 });
 
-function Dropdown({ children, className }: DropdownProps) {
+function Dropdown({ children, className, ...props }: DropdownProps) {
   return (
     <Menu>
       {({ isExpanded }) => {
         return (
-          <DropdownContent isExpanded={isExpanded} className={className}>
+          <DropdownContent isExpanded={isExpanded} data-testid={props["data-testid"]} className={className}>
             {children}
           </DropdownContent>
         );
@@ -89,20 +129,26 @@ function Dropdown({ children, className }: DropdownProps) {
   );
 }
 
-function DropdownContent({ children, isExpanded, className }: DropdownContentProps) {
+function DropdownContent({ children, isExpanded, className, ...props }: DropdownContentProps) {
   const context = React.useMemo(() => ({ isExpanded }), [isExpanded]);
 
   const contentClassName = cx("relative inline-block text-left", className);
 
   return (
     <DropdownContext.Provider value={context}>
-      <div className={contentClassName}>{children}</div>
+      <div className={contentClassName} data-testid={props["data-testid"]}>
+        {children}
+      </div>
     </DropdownContext.Provider>
   );
 }
 
-function DropdownButton({ children }: DropdownButtonProps) {
-  return <MenuButton as="menu">{children}</MenuButton>;
+function DropdownButton({ children, ...props }: DropdownButtonProps) {
+  return (
+    <MenuButton as="menu" data-testid={props["data-testid"]}>
+      {children}
+    </MenuButton>
+  );
 }
 
 function DropdownItem({ children, ...props }: DropdownItemProps) {
@@ -112,12 +158,12 @@ function DropdownItem({ children, ...props }: DropdownItemProps) {
 function DropdownMenu({
   children,
   ...props
-}: React.PropsWithChildren<Record<string, unknown>> & TokenProps<"Dropdown">) {
+}: React.PropsWithChildren<Record<string, unknown>> & TokenProps<"Dropdown"> & { "data-testid"?: string }) {
   const tokens = useTokens("Dropdown", props.tokens);
   const { isExpanded } = React.useContext(DropdownContext);
 
   return (
-    <MenuPopover className="z-50">
+    <MenuPopover className="z-50" data-testid={props["data-testid"]}>
       <Transition show={isExpanded} {...tokens.Menu.transition}>
         <MenuItems>{children}</MenuItems>
       </Transition>

--- a/libs/menu/src/DropdownMenu.tsx
+++ b/libs/menu/src/DropdownMenu.tsx
@@ -98,6 +98,7 @@ type DropdownMenuMenuItemProps = {
   type?: "submit" | "reset" | "button";
   children: React.ReactNode;
   onSelect: () => void;
+  "data-testid"?: string;
 } & TokenProps<"DropdownMenu">;
 
 type DropdownMenuContainerProps = {
@@ -154,7 +155,7 @@ function DropdownMenu({
   );
 
   return (
-    <Dropdown>
+    <Dropdown data-testid={props["data-testid"]}>
       <Dropdown.Button>
         {menuType === "text" && (
           <Button
@@ -165,18 +166,27 @@ function DropdownMenu({
             trailingIcon={iconPlacement === "trailing" && responsiveIcon}
             className={className}
             {...props}
+            data-testid={props["data-testid"] && `${props["data-testid"]}-button`}
           >
             {title}
           </Button>
         )}
         {menuType === "icon" && (
-          <Button type={type} variant={variant} color={color} menu={true} className={className} {...props}>
+          <Button
+            type={type}
+            variant={variant}
+            color={color}
+            menu={true}
+            className={className}
+            {...props}
+            data-testid={props["data-testid"] && `${props["data-testid"]}-button`}
+          >
             {responsiveIcon}
           </Button>
         )}
       </Dropdown.Button>
 
-      <Dropdown.Menu>
+      <Dropdown.Menu data-testid={props["data-testid"] && `${props["data-testid"]}-menu`}>
         <DropdownContext.Provider value={{ isExpanded: true, itemHeight, setItemHeight }}>
           <DropdownMenuContainer backgroundColor={popupBackgroundColor} visibleItemCount={visibleItemCount}>
             {children}
@@ -215,8 +225,14 @@ export function DropdownMenuItem({
   );
 
   return (
-    <Dropdown.Item {...props}>
-      <button type="button" className={dropdownMenuItemClassName} disabled={disabled} ref={itemRef}>
+    <Dropdown.Item {...props} data-testid={props["data-testid"] && `${props["data-testid"]}-wrapper`}>
+      <button
+        type="button"
+        className={dropdownMenuItemClassName}
+        disabled={disabled}
+        ref={itemRef}
+        data-testid={props["data-testid"]}
+      >
         {children}
       </button>
     </Dropdown.Item>

--- a/libs/menu/src/SidebarNavigation.tsx
+++ b/libs/menu/src/SidebarNavigation.tsx
@@ -61,6 +61,19 @@ type SidebarNavigationProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & SidebarNavigationTokensProps;
 
 type SidebarNavigationTokensProps = {
@@ -103,6 +116,19 @@ type SidebarNavigationItemProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & SidebarNavigationTokensProps;
 
 type SidebarNavigationDropdownItemProps = {
@@ -137,6 +163,19 @@ type SidebarNavigationDropdownItemProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & SidebarNavigationTokensProps;
 
 type SidebarNavigationDropdownProps = {
@@ -252,7 +291,7 @@ function SidebarNavigation({
     <NavigationContextProvider menuOpened={isOpen} actionOpened={false}>
       <NavigationContext.Consumer>
         {({ isActionOpened }) => (
-          <div className={containerClassName}>
+          <div className={containerClassName} data-testid={props["data-testid"]}>
             <div className={tokens.topContainer}>
               {!isActionOpened && (
                 <>
@@ -262,11 +301,16 @@ function SidebarNavigation({
                       color={menuButtonClassName}
                       variant="text"
                       onClick={handleClick}
+                      data-testid={props["data-testid"] && `${props["data-testid"]}-menu`}
                     >
                       {menuIcon}
                     </Button>
                   </div>
-                  {logo && <div className={logoClassName}>{logo}</div>}
+                  {logo && (
+                    <div className={logoClassName} data-testid={props["data-testid"] && `${props["data-testid"]}-logo`}>
+                      {logo}
+                    </div>
+                  )}
                 </>
               )}
               {topRightAction && (
@@ -274,14 +318,24 @@ function SidebarNavigation({
                   className={`flex items-center justify-end md:justify-center md:mr-0 md:col-span-1 ${
                     !isActionOpened ? (logo ? "col-span-1 mr-4" : "col-span-2 mr-4") : "col-span-3"
                   }`}
+                  data-testid={props["data-testid"] && `${props["data-testid"]}-right-action`}
                 >
                   {topRightAction}
                 </div>
               )}
             </div>
             <div className={navClass}>
-              <nav className={navClassName}>{children}</nav>
-              {bottomActions && <div className={bottomActionsClassName}>{bottomActions}</div>}
+              <nav className={navClassName} data-testid={props["data-testid"] && `${props["data-testid"]}-navigation`}>
+                {children}
+              </nav>
+              {bottomActions && (
+                <div
+                  className={bottomActionsClassName}
+                  data-testid={props["data-testid"] && `${props["data-testid"]}-bottom-action`}
+                >
+                  {bottomActions}
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -340,7 +394,7 @@ export function SidebarNavigationItem({
   if (isExpandable) {
     return (
       <div className="cursor-pointer flex flex-col md:items-start items-center">
-        <div {...props} className={cn} onClick={() => setExpanded(!expanded)}>
+        <div {...props} className={cn} onClick={() => setExpanded(!expanded)} data-testid={props["data-testid"]}>
           {icon && <div className={iconClassName}>{icon}</div>}
           {title}
           {expanded ? closeExpanderIcon : openExpanderIcon}
@@ -351,7 +405,7 @@ export function SidebarNavigationItem({
   }
 
   return (
-    <Link {...props} to={to || "#"} className={cn}>
+    <Link {...props} to={to || "#"} className={cn} data-testid={props["data-testid"]}>
       {icon && <div className={iconClassName}>{icon}</div>}
       <div className="flex items-center">{title || children}</div>
     </Link>
@@ -408,6 +462,7 @@ export function SidebarNavigationDropdown({
           iconColor={iconColor}
           visibleItemCount={visibleItemCount}
           popupBackgroundColor={popupBackgroundColor || "default"}
+          data-testid={props["data-testid"]}
         >
           <div className="px-2">{children}</div>
         </DropdownMenu>
@@ -417,6 +472,7 @@ export function SidebarNavigationDropdown({
           variant={buttonVariant}
           color={buttonColor}
           onClick={() => (onActionOpenedToggle ? onActionOpenedToggle(!isActionOpened) : undefined)}
+          data-testid={props["data-testid"]}
         >
           {icon ? React.cloneElement(icon, { className: mobileIconClassName }) : title}
         </Button>
@@ -461,7 +517,7 @@ export function SidebarNavigationDropdownItem({
   };
 
   return (
-    <Link to={to ? to : ""} onClick={onSelect} className={dropdownItemClassName}>
+    <Link to={to ? to : ""} onClick={onSelect} className={dropdownItemClassName} data-testid={props["data-testid"]}>
       {icon ? iconTextWrapper(children) : children}
     </Link>
   );

--- a/libs/menu/src/TopNavigation.tsx
+++ b/libs/menu/src/TopNavigation.tsx
@@ -69,6 +69,19 @@ export type TopNavigationProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TopNavigationTokensProps;
 
 type TopNavigationTokensProps = {
@@ -125,6 +138,19 @@ export type TopNavigationItemProps = {
    * Destination url.
    */
   to?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TopNavigationItemsTokensProps;
 
 type TopNavigationDropdownProps = {
@@ -202,6 +228,19 @@ type TopNavigationDropdownItemProps = {
    * Custom additional class name for the main container component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & TopNavigationItemsTokensProps;
 
 type TopNavigationActionProps = {
@@ -241,6 +280,7 @@ type ThemeNavigationMenuContainerProps = {
   variant: "basic" | "centered" | "contained";
   className: string;
   color?: "default" | "dark" | "light";
+  "data-testid"?: string;
 } & TokenProps<"TopNavigation">;
 
 function TopNavigation({
@@ -305,7 +345,7 @@ function TopNavigation({
     <NavigationContextProvider small={false} menuOpened={isOpen} actionOpened={false}>
       <NavigationContext.Consumer>
         {({ isActionOpened }) => (
-          <nav className={baseClassName}>
+          <div className={baseClassName} data-testid={props["data-testid"]}>
             <div className={containerClassName}>
               {!isActionOpened && (
                 <>
@@ -315,14 +355,24 @@ function TopNavigation({
                       color={menuButtonClassName}
                       variant="text"
                       onClick={handleClick}
+                      data-testid={props["data-testid"] && `${props["data-testid"]}-menu`}
                     >
                       {isOpen ? closeIcon : menuIcon}
                     </Button>
                   </div>
-                  {logo && variant === "centered" && <div className={logoClassName}>{logo}</div>}
+                  {logo && variant === "centered" && (
+                    <div className={logoClassName} data-testid={props["data-testid"] && `${props["data-testid"]}-logo`}>
+                      {logo}
+                    </div>
+                  )}
                   <div className={topNavigationTokens.innerContainer}>
                     {logo && (variant === "basic" || variant === "contained") && (
-                      <div className={logoClassName}>{logo}</div>
+                      <div
+                        className={logoClassName}
+                        data-testid={props["data-testid"] && `${props["data-testid"]}-logo`}
+                      >
+                        {logo}
+                      </div>
                     )}
                     {(variant === "basic" || variant === "contained") && (
                       <TopNavigationMenuContainer variant={variant} className={headerClasses}>
@@ -334,18 +384,33 @@ function TopNavigation({
               )}
               {topRightAction && (
                 <div className={`flex items-center justify-end md:mr-2 ${isActionOpened ? "col-span-3 mt-2" : "mr-4"}`}>
-                  <div className={`${isActionOpened && "w-full md:w-fit"}`}>{topRightAction}</div>
+                  <div
+                    className={`${isActionOpened && "w-full md:w-fit"}`}
+                    data-testid={props["data-testid"] && `${props["data-testid"]}-right-action`}
+                  >
+                    {topRightAction}
+                  </div>
                 </div>
               )}
               {searchBar && (
                 <div className={searchBarClasses}>
-                  <div className={topNavigationTokens.searchBar}>{searchBar}</div>
+                  <div
+                    className={topNavigationTokens.searchBar}
+                    data-testid={props["data-testid"] && `${props["data-testid"]}-search`}
+                  >
+                    {searchBar}
+                  </div>
                 </div>
               )}
               {actions && (
                 <div className={topNavigationTokens.actionsAndDropdownContainer}>
                   <div className={topNavigationTokens.innerActionsAndDropdownContainer}>
-                    <div className={topNavigationTokens.actionsContainer}>{actions}</div>
+                    <div
+                      className={topNavigationTokens.actionsContainer}
+                      data-testid={props["data-testid"] && `${props["data-testid"]}-actions`}
+                    >
+                      {actions}
+                    </div>
                   </div>
                 </div>
               )}
@@ -355,14 +420,18 @@ function TopNavigation({
                 {navigation}
               </TopNavigationMenuContainer>
             )}
-
             <div className={topNavigationTokens.smallMenuContainer}>
               <div className={menuClasses}>
-                <div className={topNavigationTokens.smallMenuInnerContainer}>{navigation}</div>
+                <nav
+                  className={topNavigationTokens.smallMenuInnerContainer}
+                  data-testid={props["data-testid"] && `${props["data-testid"]}-navigation`}
+                >
+                  {navigation}
+                </nav>
                 {actions}
               </div>
             </div>
-          </nav>
+          </div>
         )}
       </NavigationContext.Consumer>
     </NavigationContextProvider>
@@ -386,7 +455,12 @@ function TopNavigationMenuContainer({
 
   return (
     <div className={menuContainerClassName}>
-      <div className={innerMenuContainerClassName}>{children}</div>
+      <nav
+        className={innerMenuContainerClassName}
+        data-testid={props["data-testid"] && `${props["data-testid"]}-navigation`}
+      >
+        {children}
+      </nav>
     </div>
   );
 }
@@ -452,13 +526,20 @@ export function TopNavigationItem({
             tokens={{}}
             className={cn}
             popupBackgroundColor={backgroundColor ? backgroundColor : color}
+            data-testid={props["data-testid"]}
           >
             {children}
           </DropdownMenu>
         </div>
         <div className="md:hidden">
           <div className="flex flex-col flex-wrap items-center">
-            <Link {...props} to={to || "#"} className={cn + ` items-center`} onClick={() => setExpanded(!expanded)}>
+            <Link
+              {...props}
+              to={to || "#"}
+              className={cn + ` items-center`}
+              onClick={() => setExpanded(!expanded)}
+              data-testid={props["data-testid"]}
+            >
               {title}
               {expanded ? closeExpanderIcon : openExpanderIcon}
             </Link>
@@ -533,6 +614,7 @@ export function TopNavigationDropdown({
           closeExpanderIcon={icon}
           iconColor={iconColor}
           popupBackgroundColor={popupBackgroundColor || "default"}
+          data-testid={props["data-testid"]}
         >
           <div className="px-2">{children}</div>
         </DropdownMenu>
@@ -543,6 +625,7 @@ export function TopNavigationDropdown({
           color={buttonColor}
           onClick={() => (onActionOpenedToggle ? onActionOpenedToggle(!isActionOpened) : undefined)}
           className="flex items-center justify-center space-x-2"
+          data-testid={props["data-testid"]}
         >
           {icon ? React.cloneElement(icon, { className: mobileIconClassName }) : title}
         </Button>
@@ -599,7 +682,12 @@ export function TopNavigationDropdownItem({
 
   if (small) {
     return (
-      <Link to={to ? to : ""} onClick={onSelect} className={smallDropdownItemClassName}>
+      <Link
+        to={to ? to : ""}
+        onClick={onSelect}
+        className={smallDropdownItemClassName}
+        data-testid={props["data-testid"]}
+      >
         {icon ? iconTextWrapper(children) : children}
       </Link>
     );

--- a/libs/selectors/src/PageResizer.tsx
+++ b/libs/selectors/src/PageResizer.tsx
@@ -56,6 +56,19 @@ type PageResizerProps = {
    * Custom additional styling applied to the component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & PageResizerTokensProps;
 
 type PageResizerTokensProps = {
@@ -85,6 +98,7 @@ export default function PageResizer({ pageSizes, onPageSizeChange, children, cla
       onChange={onChange}
       onBlur={() => ({})}
       className={selectClassName}
+      data-testid={props["data-testid"] && `${props["data-testid"]}-select`}
     />
   );
 
@@ -97,18 +111,16 @@ export default function PageResizer({ pageSizes, onPageSizeChange, children, cla
   }
 
   return (
-    <div>
-      <p className={tokens.master}>
-        {intl ? (
-          <Intl name={intl.commonKeys["pageResizerSummary"] as string} params={{ pageSizeSelect: pageSizeSelect }}>
-            {{
-              pageSizeSelect: () => pageSizeSelect,
-            }}
-          </Intl>
-        ) : (
-          <>Show {pageSizeSelect} results per page</>
-        )}
-      </p>
+    <div className={tokens.master} data-testid={props["data-testid"]}>
+      {intl ? (
+        <Intl name={intl.commonKeys["pageResizerSummary"] as string} params={{ pageSizeSelect: pageSizeSelect }}>
+          {{
+            pageSizeSelect: () => pageSizeSelect,
+          }}
+        </Intl>
+      ) : (
+        <>Show {pageSizeSelect} results per page</>
+      )}
     </div>
   );
 }

--- a/libs/selectors/src/TreeSelect.tsx
+++ b/libs/selectors/src/TreeSelect.tsx
@@ -139,17 +139,31 @@ export type TreeSelectProps<T> = {
   filter?: (query: string, item: T) => boolean;
 
   /**
-   * A unique identifier for testing purposes, equivalent to the 'data-testid' attribute.
+   * A unique identifier for testing purposes.
    * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
    * It helps ensure that UI components are behaving as expected across different scenarios.
    * @type {string}
    * @example
    * // Usage:
-   * <MyComponent testId="my-component" />
+   * <MyComponent data-testid="my-component" />
    * // In tests:
    * getByTestId('my-component');
    */
-  testId?: string;
+  "data-testid"?: string;
+
+  /**
+   * A function that generates a unique data-testid identifier for individual items.
+   * The function accepts an item of type `T` and returns a string that can be
+   * used as the `data-testid` for that item. By incorporating unique properties
+   * of the item, it ensures that each element has a distinct identifier.
+   *
+   * // Example function:
+   * const itemTestId = (item) => `list-item-${item.id}`;
+   *
+   * // Example test:
+   * getByTestId('list-item-123');
+   */
+  "item-testid"?: (item: T) => string;
 } & OptionProps<T> &
   SelectTokensProps;
 
@@ -162,6 +176,7 @@ type TreeSelectOptionsProps<T> = {
   highlightedIndex: number;
   closeMenu: () => void;
   expanded?: boolean;
+  testId?: (item: T) => string;
 } & OptionProps<T>;
 
 type TreeSelectOptionProps<T> = {
@@ -170,6 +185,7 @@ type TreeSelectOptionProps<T> = {
   highlightedIndex: number;
   closeMenu: () => void;
   initialExpanded?: boolean;
+  testId?: (item: T) => string;
 } & OptionProps<T> &
   TokenProps<"Select">;
 
@@ -426,7 +442,7 @@ export default function TreeSelect<T>({
         ref={inputRef}
         className={className}
         id={id}
-        testId={props.testId || id}
+        data-testid={props["data-testid"] ?? id}
         label={label}
         help={help}
         tooltip={props.tooltip}
@@ -441,7 +457,11 @@ export default function TreeSelect<T>({
             {value && getValueLabel && <div className={valueLabelClassName}>{getValueLabel(value)}</div>}
             <div className="flex flex-row items-center">
               {!disabled && value && (
-                <div className={clearClassName} onClick={clear}>
+                <div
+                  className={clearClassName}
+                  onClick={clear}
+                  data-testid={props["data-testid"] && `${props["data-testid"]}-clear`}
+                >
                   {clearIcon}
                 </div>
               )}
@@ -485,6 +505,7 @@ export default function TreeSelect<T>({
                   closeMenu={closeMenu}
                   expanded={inputValue.length > 0}
                   highlightedIndex={highlightedIndex}
+                  testId={props["item-testid"]}
                 />
               )}
             </div>
@@ -495,7 +516,7 @@ export default function TreeSelect<T>({
   );
 }
 
-function TreeSelectOptions<T>({ options, expanded, highlightedIndex, ...props }: TreeSelectOptionsProps<T>) {
+function TreeSelectOptions<T>({ options, expanded, highlightedIndex, testId, ...props }: TreeSelectOptionsProps<T>) {
   return (
     <>
       {options.map((option, index) => (
@@ -506,6 +527,7 @@ function TreeSelectOptions<T>({ options, expanded, highlightedIndex, ...props }:
           highlightedIndex={highlightedIndex}
           option={option}
           initialExpanded={expanded}
+          testId={testId}
         />
       ))}
     </>
@@ -522,6 +544,7 @@ function TreeSelectOption<T>({
   initialExpanded = false,
   index,
   highlightedIndex,
+  testId,
   ...props
 }: TreeSelectOptionProps<T>) {
   const tokens = useTokens("TreeSelect", props.tokens);
@@ -565,7 +588,7 @@ function TreeSelectOption<T>({
 
   return (
     <div>
-      <div className={itemClassName} onClick={onItemClick}>
+      <div className={itemClassName} onClick={onItemClick} data-testid={testId && testId(option)}>
         <div className={levelClasses[level]}>
           <div className={innerItemClassName}>
             {childOptions.length > 0 && icon}
@@ -583,6 +606,7 @@ function TreeSelectOption<T>({
           closeMenu={closeMenu}
           expanded={initialExpanded}
           highlightedIndex={highlightedIndex}
+          testId={testId}
         />
       )}
     </div>

--- a/libs/upload/src/DragZone.tsx
+++ b/libs/upload/src/DragZone.tsx
@@ -104,6 +104,19 @@ export type DragZoneProps<T extends File> = {
    * Doesn't adjust uploading percentages for the additional delay time, so UX behaviour needs to be additionally checked.
    */
   postLoadDelay?: number;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & Omit<UploadyWrapperProps, "children"> &
   Omit<FieldProps, "children"> &
   DragZoneTokensProps;
@@ -165,6 +178,19 @@ type CustomUploadDropZoneContainerProps<T extends File> = {
    * @see {@link DragZoneProps#postLoadDelay}
    */
   postLoadDelay?: number;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 type CustomUploadDropZoneProps = {
@@ -179,6 +205,7 @@ type CustomUploadDropZoneProps = {
   loader?: ((uploadPercentage: number) => React.ReactNode) | null;
   preLoadDelay?: number;
   postLoadDelay?: number;
+  "data-testid"?: string;
 } & TokenProps<"DragZone">;
 
 export default function DragZone<T extends File>({
@@ -205,7 +232,7 @@ export default function DragZone<T extends File>({
   const onDragOverClassName = "opacity-50";
 
   return (
-    <Field {...props}>
+    <Field {...props} data-testid={props["data-testid"] && `${props["data-testid"]}-wrapper`}>
       {!disabled ? (
         <UploadyWrapper
           url={url}
@@ -227,6 +254,7 @@ export default function DragZone<T extends File>({
               loader={loader}
               preLoadDelay={preLoadDelay}
               postLoadDelay={postLoadDelay}
+              data-testid={props["data-testid"]}
             />
           </UploadDropZone>
         </UploadyWrapper>
@@ -346,7 +374,7 @@ function CustomUploadDropZone({
   const showLoader = loader && ((preLoadDelayPassed && uploadActive) || postUploadPeriodActive);
 
   return (
-    <div className={customUploadDropZoneContainerClassName} onClick={onClick}>
+    <div className={customUploadDropZoneContainerClassName} onClick={onClick} data-testid={props["data-testid"]}>
       <div className={tokens.customUploadDropZoneDescriptionContainer}>
         {showLoader && loader && uploadPercentage ? loader(uploadPercentage) : uploadZoneIcon}
         <label className={customUploadDropZoneTitleClassName}>{title}</label>

--- a/libs/upload/src/FileList.tsx
+++ b/libs/upload/src/FileList.tsx
@@ -41,16 +41,26 @@ export type FileListProps<T extends File> = {
    * Custom additional styling applied to the component.
    */
   className?: string;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 };
 
 export type FileListNameProps = {
   children?: React.ReactNode;
   fileIcon?: React.ReactElement;
-
-  /**
-   * Custom additional styling applied to the component.
-   */
   className?: string;
+  "data-testid"?: string;
 } & TokenProps<"FileList">;
 
 export type FileListActionsProps = {
@@ -58,12 +68,26 @@ export type FileListActionsProps = {
    * Used in case of redirect, for example, file content url
    */
   to?: string;
+
   children?: React.ReactNode;
 
   /**
    * Handler for click action
    */
   onClick?: React.MouseEventHandler<HTMLElement>;
+
+  /**
+   * A unique identifier for testing purposes.
+   * This identifier can be used in testing frameworks like Jest or Cypress to locate specific elements for testing.
+   * It helps ensure that UI components are behaving as expected across different scenarios.
+   * @type {string}
+   * @example
+   * // Usage:
+   * <MyComponent data-testid="my-component" />
+   * // In tests:
+   * getByTestId('my-component');
+   */
+  "data-testid"?: string;
 } & React.AnchorHTMLAttributes<HTMLAnchorElement> &
   TokenProps<"FileList">;
 
@@ -111,10 +135,12 @@ export type FileHeaderProps = {
    * Custom additional styling applied to the component.
    */
   className?: string;
+  "data-testid"?: string;
 } & TokenProps<"FileList">;
 
 export type FileBodyProps = {
   children: React.ReactNode;
+  "data-testid"?: string;
 };
 
 function FileHeader({ expandable = false, children, className, ...props }: FileHeaderProps) {
@@ -142,13 +168,14 @@ function FileHeader({ expandable = false, children, className, ...props }: FileH
   const closeExpanderIcon = useIcon("closeExpander", props.closeExpanderIcon, { size: 3 });
 
   return (
-    <div className={containerClassName}>
+    <div className={containerClassName} data-testid={props["data-testid"]}>
       {children}
       {expandable ? (
         <IconButton
           icon={isExpanded ? closeExpanderIcon : openExpanderIcon}
           className="ml-2"
           onClick={toggleExpander}
+          data-testid={props["data-testid"] && `${props["data-testid"]}-expander`}
           showTooltip={false}
         />
       ) : (
@@ -158,14 +185,14 @@ function FileHeader({ expandable = false, children, className, ...props }: FileH
   );
 }
 
-function FileBody({ children }: FileBodyProps) {
+function FileBody({ children, ...props }: FileBodyProps) {
   const { isExpanded } = React.useContext(FileContext);
 
   if (isExpanded === false) {
     return null;
   }
 
-  return <div>{children}</div>;
+  return <div data-testid={props["data-testid"]}>{children}</div>;
 }
 
 function FileListName({ children, className, fileIcon, ...props }: FileListNameProps) {
@@ -179,7 +206,7 @@ function FileListName({ children, className, fileIcon, ...props }: FileListNameP
   const fileListNameClassName = cx(tokens.fileName.textColor, tokens.fileName.fontSize);
 
   return (
-    <div className={containerClassName}>
+    <div className={containerClassName} data-testid={props["data-testid"]}>
       {finalFileIcon}
       <span className={fileListNameClassName}>{children}</span>
     </div>
@@ -195,14 +222,14 @@ function FileListAction({ to, children, className, ...props }: FileListActionsPr
 
   return (
     <div className={containerClassName}>
-      <a href={to} className={actionsClassName} {...props}>
+      <a href={to} className={actionsClassName} {...props} data-testid={props["data-testid"]}>
         {children}
       </a>
     </div>
   );
 }
 
-export function FileList<T extends File>({ hook, children, className }: FileListProps<T>) {
+export function FileList<T extends File>({ hook, children, className, ...props }: FileListProps<T>) {
   const helpers = {
     deleteFile: (selectedFile: T) => {
       hook.onDeletedFiles(selectedFile);
@@ -212,14 +239,22 @@ export function FileList<T extends File>({ hook, children, className }: FileList
   const files = hook.uploadedFiles.map((file) => {
     return (
       <FileContextProvider>
-        <li key={file.id} className="">
+        <li
+          key={file.id}
+          className=""
+          data-testid={props["data-testid"] && `${props["data-testid"]}-${file.name || file.originalFileName}`}
+        >
           {children ? children(file, helpers) : null}
         </li>
       </FileContextProvider>
     );
   });
 
-  return <ul className={className}>{files}</ul>;
+  return (
+    <ul className={className} data-testid={props["data-testid"]}>
+      {files}
+    </ul>
+  );
 }
 
 FileHeader.Name = FileListName;


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.16.0
* Module: menu

## Description

### Summary

Renamed existing `testId` prop to `data-testid` on existing components.

Extended the `data-testid` prop to a wide array of components. Excluded components list is below:
- Amount
- Date
- DateTime
- Number
- FormLayout
- Slider
- Intl
- AppPicker
- SidebarLayout
- StackedLayout

Also introduced a new `item-testid` prop to `TreeSelect`, `Select` and `Autocomplete` in order to apply arbitrary `data-testid` values to individual items in the dropdown menu.

### Related issue

#272 

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
