### PR TITLE
#304 - Forward defaultRichTextElements to react-intl context

### DIFF
--- a/libs/intl/src/IntlProvider.tsx
+++ b/libs/intl/src/IntlProvider.tsx
@@ -65,6 +65,12 @@ type IntlProviderProps = {
    * Configuration for label keys used internally in Tiller (like 'Required'). Override these if you cannot use default keys provided by Tiller.
    */
   keyConfig?: CommonKeys;
+
+  /**
+   * Defines custom render functions for rich text elements (e.g. <b>, <i>, <a>) used in translated messages.
+   * Useful when you want to control the styling or behavior of specific tags in your localized content.
+   */
+  defaultRichTextElements?: Record<string, (chunks: React.ReactNode) => React.ReactNode>;
 };
 
 type IntlProviderWrapperProps = {
@@ -155,12 +161,12 @@ function IntlProviderWrapper({ children, intl }: IntlProviderWrapperProps) {
   return <IntlContext.Provider value={value}>{children}</IntlContext.Provider>;
 }
 
-export default function IntlProvider({ children, lang, dictionary, loadDictionary, keyConfig }: IntlProviderProps) {
+export default function IntlProvider({ children, lang, dictionary, loadDictionary, keyConfig, defaultRichTextElements }: IntlProviderProps) {
   const intl = useIntl(lang, dictionary, loadDictionary, keyConfig);
 
   return (
     <>
-      <ReactIntlProvider locale={lang}>
+      <ReactIntlProvider locale={lang} defaultRichTextElements={defaultRichTextElements} >
         <IntlProviderWrapper intl={intl}>{children}</IntlProviderWrapper>
       </ReactIntlProvider>
     </>


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version: 1.17.0
* Module: intl

## Description

### Summary

Adds support for defaultRichTextElements prop to IntlProvider, allowing consumers to customize how rich text elements are rendered in translated messages.

### Related issue

#304 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
