### PR TITLE
fix: PageResizer with client size Pagination goes beyond last page when page size changes to lower number

### DIFF
--- a/storybook/src/selectors/PageResizer.stories.tsx
+++ b/storybook/src/selectors/PageResizer.stories.tsx
@@ -96,6 +96,11 @@ export const WithPagination = () => {
   const [pageSize, setPageSize] = React.useState(5);
   const [paginationState, paginationHook] = useLocalPagination(items, pageSize);
 
+  const onPageSizeChange = (pageSize: number) => {
+    setPageSize(pageSize);
+    paginationHook.onPageChange(0);
+  };
+
   return (
     <>
       <div className={`flex space-x-2 p-2 rounded-md w-fit`}>
@@ -103,7 +108,7 @@ export const WithPagination = () => {
       </div>
       <div className="flex flex-col space-y-4 mt-4 w-fit">
         <Pagination {...paginationState} {...paginationHook} />
-        <PageResizer {...paginationState} pageSizes={[3, 5, 10]} onPageSizeChange={setPageSize} />
+        <PageResizer {...paginationState} pageSizes={[3, 5, 10]} onPageSizeChange={onPageSizeChange} />
       </div>
     </>
   );


### PR DESCRIPTION
<!--
  Please use Markdown syntax throughout the report for improved clarity.
  https://guides.github.com/features/mastering-markdown/
-->

## Basic information

* Tiller version:  **0.0.0-dev**
  <!-- released version -->
* Module: **StoryBook**
## Additional information

<!-- Please, include any additional information that could be relevant (e.g. npm/yarn, OS version). -->

## Description

### Summary

<!--- Please, provide a short summary of your changes. -->
The issue was in the WithPagination story. The previous implementation wasn't handling resetting the page when the page size changes, which lead to the issues described.

### Details
I've updated the WithPagination story to fix the pagination issue.
- Added a new onPageSizeChange handler that:
- Updates the page size using setPageSize
- Resets the pagination to the first page using paginationHook.onPageChange(0)
- Updated the PageResizer component to use the new onPageSizeChange handler instead of directly using setPageSize

<!--- Please, describe your changes in detail. -->

### Related issue
Fixes #309 
<!--
  If there is a related issue, please provide a reference to it.
  If the related issue does not exist, please consider creating one.
-->

## Types of changes

<!--- What types of changes does your code introduce? Please, remove all points that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.
  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike through the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's Prettier code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added a story to cover my changes
- [x] All new and existing story tests pass
